### PR TITLE
Dialogue Addition

### DIFF
--- a/Regression Dialogue/Content.json
+++ b/Regression Dialogue/Content.json
@@ -1,0 +1,30 @@
+{
+    "Format": "1.19.0",
+    "Changes": [
+		{
+            "LogName": "Sebastian",
+            "Action": "Include",
+            "FromFile": "Dialogue/NPCs/Sebastian.json"
+        },
+		{
+            "LogName": "Jodi",
+            "Action": "Include",
+            "FromFile": "Dialogue/NPCs/Jodi.json"
+        },
+		{
+            "LogName": "Sam",
+            "Action": "Include",
+            "FromFile": "Dialogue/NPCs/Sam.json"
+        },		
+		{
+            "LogName": "Vincent",
+            "Action": "Include",
+            "FromFile": "Dialogue/NPCs/Vincent.json"
+        },
+		{
+		    "LogName": "Jas",
+            "Action": "Include",
+            "FromFile": "Dialogue/NPCs/Jas.json"
+		},	
+	]
+}

--- a/Regression Dialogue/Dialogue/NPCs/Jas.json
+++ b/Regression Dialogue/Dialogue/NPCs/Jas.json
@@ -1,0 +1,23 @@
+{
+	"Changes":[
+		{
+			"LogName":"Jas",
+			"Action":"EditData",
+			"Target":"Characters/Dialogue/Jas",
+			"Entries":{	
+			
+			  "Introduction": "...$u#$b#Hi...$u
+  #$q 101/102 ABDLChild_fallback#%Would you be comfortable seeing ABDL dialogue from Vincent and Jas?
+  #$r 101 0 ABDLChild_Yes#Yes, I am comfortable with that.
+  #$r 102 0 ABDLChild_No#No, I would like to see the original dialogue.",
+  //-----------------
+  "ABDLChild_Yes":"%The more hearts you have with them the more ABDL dialogue there will be.",
+  "ABDLChild_No":"%Okay. All the original lines will be unchanged, and they also won't notice you using your pants.",
+  "ABDLChild_fallback":"#$p 102#...$u|%The waistband of Jas's pull up faintly peeks out.",
+  //The question above happens durring the introduction of Vincent or Jas, whomever the player interacts with first. They'll get to choose whether or not they want ABDL dialogue for the two of them. 
+  //Unfortunately, this only works for new farms, not if a player installs the mod and loads an old save where they've already met both Vincent and Jas. Then it defaults to the ABDL text.			
+
+			},
+		},
+	]
+}

--- a/Regression Dialogue/Dialogue/NPCs/Jodi.json
+++ b/Regression Dialogue/Dialogue/NPCs/Jodi.json
@@ -1,0 +1,64 @@
+{
+	"Changes":[
+		{
+			"LogName":"Jodi",
+			"Action":"EditData",
+			"Target":"Characters/Dialogue/Jodi",
+			"Entries":{
+//Jodi's repsonse Ids are 110-119
+  "spring_Mon":"There's the little farmer!#$e#How's the town treating you?",
+  "spring_Mon6":"There's the little farmer!#$b#%Jodi pulls the back your waist band for a quick check.#$e#You should be okay for now.",
+  "spring_Tue4":"#$c .5#Do you have any animals on your farm? Can you tell me what the cow says?#$e#That's right! Cow goes moo!$1|Do you have any animals on your farm? Can you tell me what the chicken says?#$e#That's right! Chicken goes cluck cluck!$1",
+  "spring_Wed2":"Would you like to tell me all about your farm?#$e#%Jodi smiles at you while you gush about how pretty your farm is.#$e#What a clever little boy you are.$1^What a clever little girl you are.$1",
+  "spring_Wed8":"Would you like to tell me all about your farm?#$e#%Jodi smiles at you while you gush about how pretty your farm is. You barely even notice her hand check to see if your pants are still dry.#$e#What a clever little boy you are.$1^What a clever little girl you are.$1",
+  "spring_Thu2":"Sam still sleeps with his old teddy bear, though, he tries to hide it in the morning.#$e#I don't know what to say to make him feel less embarassed about it.$2",
+  "spring_Fri":"How are you doing @? Are you eating enough?#$e#...Do you have enough... supplies?",
+  "spring_Fri4":"How are you doing @? Are you eating enough?#$e#I bet you've already run out of the diapers I gave you by now.#$e#I sure hope your farm is making enough money to buy more!$1#$e#",
+  "spring_Sat4":"#$p 102#I'm so glad you're trying to improve that old farm.|Vincent fell asleep on my lap yesterday.#$e#It was so precious, I never wanted it to end!$1",
+  "spring_Sun6":"Being motherly makes me feel important.#$b#Even if the little ones aren't my own!$1#$e#%Jodi gives you a wink.",
+
+
+  "summer_Mon6":"%Jodi sees you standing nearby and holds out her hand. You grab onto her sleeve and smile up at her.#$e#Awwwww.",
+  "summer_Mon10":"%Jodi sees you standing nearby and holds out her hand. You grab onto her sleeve as your thumb finds its way into your mouth without you noticing.#$e#Awwwww. Well aren't you a precious little boy.^Well aren't you a precious little girl.$1",
+  "summer_Tue6":"#$p 102#Sam tries really hard to act like a big kid, but he still melts when I pet his hair just like when he was a little boy.|Sometimes I catch Sam watching me change Vincent.#$e#He almost looks jealous.$1",
+"summer_Wed8":"Oh hi there @!#$q 110/111 Show_Followup#Oh, do you want to show me something?
+#$r 110 0 Show_Nice#Show her the pretty flower you picked.
+#$r 110 0 Show_Nice#Show her the cool rock you found in the mines.
+#$r 110 0 Show_Nice#Show her your favorite plushie.
+#$r 111 0 Show_Diaper#Show her your diaper.",
+"Show_Nice": "%Jodi holds it delicately, looking at it like it's the most important thing in the world.#$b#This is wonderful! Thank you for showing me.$1#$b#%Jodi gives it back and pats your head affectionately.", 
+"Show_Diaper": "%Jodi grins at your proud display.#$b#Well isn't that something!$1#$b#Let's see if it's still clean.#$b#%Jodi presses her hand against your diaper, giving it a thorough check.",
+"Show_Followup":"Well don't you look excited!$1#$e#%Jodi pats your head fondly.",
+  "summer_Thu4":"That farm seems like a lot of work for such a little farmer! I guess you're only pretending to be so little.#$e#%Jodi winks at you.",
+  "summer_Fri8":"#$p 102#Maintaining a household is difficult work... but somebody has to do it.|Vincent doesn't show any signs of getting out of diapers any time soon.#$e#I guess he'll just be my little boy for a little bit longer.$1",
+  "summer_Sat":"%Jodi is humming a soft song to herself while she goes about her business. It's familiar somehow.",
+  "summer_Sat10":"%Jodi is humming a soft song to herself while she goes about her business. It's familiar somehow.#$e#%She notices you paying attention and smiles. Without stopping her hum, she pulls you into a hug, letting you feel the comforting hum in her chest.#$e#Looks like someone might need a nap.",
+  "summer_Sun6":"Oh no! @! Is that a boo boo on your finger? What happened?$2#$b#%You tell Jodi about hurting your finger on the farm with tears in your eyes while she puts on a bandaid for you. She gives it a kiss for good measure.#$e#There we go, all better. Have fun playing!",
+  "summer_Sun10":"Oh no! @! Is that a boo boo on your finger? What happened?$2#$b#%You tell Jodi about hurting your finger on the farm with tears in your eyes while she puts on a bandaid for you.#$b#She gives it a kiss for good measure before patting your bottom to send you away.#$e#There we go, all better. Have fun playing!",
+
+
+  "fall_Mon2":"#$p 102#There's the little farmer!|Sam doesn't think I notice that Vincent's diapers run out faster than they should.#$e#I guess I still have two little boys, don't I!$1",
+  "fall_Tue4":"#$c .5#Do you have any animals on your farm? Can you tell me what the dog says?#$e#That's right! Dog says bark!$1|Do you have any animals on your farm? Can you tell me what the cat says?#$e#That's right! Cat says meow!$1",
+  "fall_Wed8":"If you ever need help with one of your little accidents, don't be afraid to ask, okay?#$e#You're so cute when you're blushing!$1",
+  "fall_Thu2":"Are you hungry?#$b#%Jodi pulls out a granola bar for you and smiles warmly as you take it.#$e#That should hold you over for now.",
+  "fall_Fri2":"#$p 102#I bet you've already run out of the diapers I gave you by now.|I guess I'd have less work to do if Vincent was potty trained.#$e#At least boys are easy to clean.",
+  "fall_Sat":"There's the little farmer!#$e#How's the town treating you?",
+  "fall_Sat8":"There's the little farmer!#$b#%Jodi pulls the back your waist band for a quick check.#$e#You should be okay for now.",
+  "fall_Sun6":"Being motherly makes me feel important.#$b#Even if the little ones aren't my own!$1#$e#%Jodi gives you a wink.",
+
+
+  "winter_Mon10":"%Jodi is humming a soft song to herself while she goes about her business. It's familiar somehow.#$e#%She notices you paying attention and smiles. Without stopping her hum, she pulls you into a hug, letting you feel the comforting hum in her chest.#$e#Looks like someone might need a nap.",
+  "winter_Tue10":"%Jodi sees you standing nearby and holds out her hand. You grab onto her sleeve as your thumb finds its way into your mouth without you noticing.#$e#Awwwww. Well aren't you a precious little boy.^Well aren't you a precious little girl.$1",
+  "winter_Wed6":"Oh no! @! Is that a boo boo on your finger? What happened?$2#$b#%You tell Jodi about hurting your finger on the farm with tears in your eyes while she puts on a bandaid for you. She gives it a kiss for good measure.#$e#There we go, all better. Have fun playing!",
+  "winter_Wed10":"Oh no! @! Is that a boo boo on your finger? What happened?$2#$b#%You tell Jodi about hurting your finger on the farm with tears in your eyes while she puts on a bandaid for you.#$b#She gives it a kiss for good measure before patting your bottom to send you away.#$e#There we go, all better. Have fun playing!",  
+  "winter_Thu4":"Sam tries really hard to act like a big kid, but he still melts when I pet his hair just like when he was a little boy.#$e#It feels nice to know he trusts me enough to let his guard down.#$e#It makes me feel like a good mother.$1",
+  "winter_Fri2":"You're a good boy. You know that, right?^You're a good girl. You know that, right?",
+  "winter_Sat6":"Maybe I should push Vincent to use the potty more, but I don't want him to feel ashamed about himself.$2#$e#He just looks so carefree playing in his diapers too. I don't want to take that away from him.",
+  "winter_Sun6":"%Jodi sees you standing nearby and holds out her hand. You grab onto her sleeve and smile up at her.#$e#Awwwww.",
+  "winter_Sun10":"%Jodi sees you standing nearby and holds out her hand. You grab onto her sleeve as your thumb finds its way into your mouth without you noticing.#$e#Awwwww. Well aren't you a precious little boy.^Well aren't you a precious little girl.$1",
+
+  
+			}
+		}
+	]
+}

--- a/Regression Dialogue/Dialogue/NPCs/Sam.json
+++ b/Regression Dialogue/Dialogue/NPCs/Sam.json
@@ -1,0 +1,210 @@
+{
+	"Changes":[
+		{
+			"LogName":"Sam",
+			"Action":"EditData",
+			"Target":"Characters/Dialogue/Sam",
+			"Entries":{	
+//Sam's repsonse Ids are 120-129		
+
+"Thu6_1": "I think my Daddy might be coming back in a year or so.#$e#I guess you might be able to meet him, then. If you're still living here.#$e#You wouldn't abandon the farm after putting so much effort into it!",
+"Fri4": "Daddy used to work as a garbage man in the city.#$e#You don't even want to know some of the things he found in people's trash.",
+"Sun8": "@! Mommy got freezy pops for us! Score!$1",
+
+"spring_Mon2":"I can't believe I have a job...$2
+#$q 120/121 Job_Followup#It almost feels like I'm not old enough yet.
+#$r 120 0 Job_Ready#You just need a little more time before you're ready.
+#$r 120 0 Job_Pretend#You could always just stop pretending to be a big boy. 
+",
+"Job_Ready": "Yeah, I guess I do, but I'm supposed to be responsible for Mommy...$9#$b#I mean Mom...$8", 
+"Job_Pretend": "Man I wish. It'd be so much better to just play all day. Just like Vincent.$4#$b#He doesn't have to work.$5", 
+"Job_Followup":"#$p 120#It felt good to admit I wasn't ready. Thank you.$3|I wonder if I should skip a day and just play in the woods all day!$1",
+
+"spring_Mon8":"#$p 102#@! Mommy got freezy pops for us! Score!$1|We watched a movie as a family last night.$7#$e#Vincent messed his diaper right at the beginning, but since he didn't seem bothered Mommy waited until the movie ended to change him.#$e#I wanted to be in his shoes.$4",
+"spring_Tue4":"After Vincent was born, things felt different.$7#$e#I missed the attention I used to get. I guess I still do.$9",
+
+"spring_Thu6":"Can I share a secret with you?$7
+#$q 122/123 Diapers_Followup#I've never told this to anybody, but I really want to go back to wearing diapers.
+#$r 122 0 Diapers_Nice#Awww, you're such a precious little boy.
+#$r 123 0 Diapers_Join#Really?! Me too! 
+",
+"Diapers_Nice": "R-Really?!$10%Sam is so overwhelmed he starts to tear up a little. You hold him close and rub his back until he calms down.#$e#T-Thanks @.$4%Sam looks like a huge weight's been lifted off his shoulders.", 
+"Diapers_Join": "Really?! For real?! You'd look so cute in one @! We could be diaper buddies!$10#$e#Man it feels weird being able to say that out loud to somebody.$4", 
+"Diapers_Followup":"I used to wet the bed until I was a teenager.$9#$b#I was embarrassed about needing diapers at night for so long! But now I miss them.$4#$b#Isn't that funny?$10",
+
+"spring_Sun8":"It's been wonderful getting to know you @. I feel like I can be perfectly honest with you.
+#$q 124/125 Little_Followup#I don't like being a big kid, I wanna go back to being a little boy.
+#$r 124 0 Little_Little#Awww, Sam. You ARE just a little boy!
+#$r 125 0 Little_Little#Looks like I'm going to need some more diapers for the little boy.
+#$r 124 0 Little_Excited#Yeah, being big is gross. We should play together!
+#$r 125 0 Little_Excited#I'll change your diapers if you change mine.
+",
+"Little_Little": "Uh huh!$3#$b#%Sam squeals happily and hides his blushing face.", 
+"Little_Excited": "Yeah!$3#$b#%Sam squeals happily and hides his blushing face.", 
+"Little_Followup":"#$p 124#You always make me feel so little. It means so much to me, thank you.$4|I really want to go back to diapers full time.$4#$b#I just don't think I can while I'm still living with Mommy.$10",
+
+"summer_Mon6": "Have you been to the desert yet?#$e#You can find some interesting things there. Daddy took me a couple times when I was younger.",
+"summer_Wed8":"We watched a movie as a family last night.$7#$b#Vincent fell asleep right away, so he wasn't in Mommy's lap like he usually is.#$b#I was sort of leaning against her shoulder, and she patted her lap so I laid my head down in it...$4#$b#It felt silly at first, but she pet my hair a lot and that was nice.$4#$e#I felt like her special little boy again.$10",
+"summer_Mon2":"I can't believe I have a job...$2
+#$q 120/121 Job_Followup#It almost feels like I'm not old enough yet.
+#$r 120 0 Job_Ready#You just need a little more time before you're ready.
+#$r 120 0 Job_Pretend#You could always just stop pretending to be a big boy. 
+",
+"Job_Ready": "Yeah, I guess I do, but I'm supposed to be responsible for Mommy...$9#$b#I mean Mom...$8", 
+"Job_Pretend": "Man I wish. It'd be so much better to just play all day. Just like Vincent.$4#$b#He doesn't have to work.$5", 
+"Job_Followup":"#$p 120#You're right, I don't think I'm quite ready to be a grown up yet.$4|I wonder if I should skip a day and just play at the beach all day!$1",
+
+"summer_Thu6":"Can I share a secret with you?$7
+#$q 122/123 Diapers_Followup#I've never told this to anybody, but I really want to go back to wearing diapers.
+#$r 122 0 Diapers_Nice#Awww, you're such a precious little boy.
+#$r 123 0 Diapers_Join#Really?! Me too! 
+",
+"Diapers_Nice": "R-Really?!$10%Sam is so overwhelmed he starts to tear up a little. You hold him close and rub his back until he calms down.#$e#T-Thanks @.$4%Sam looks like a huge weight's been lifted off his shoulders.", 
+"Diapers_Join": "Really?! For real?! You'd look so cute in one @! We could be diaper buddies!$10#$e#Man it feels weird being able to say that out loud to somebody.$4", 
+"Diapers_Followup":"I used to wet the bed until I was a teenager.$9#$b#I was embarrassed about needing diapers at night for so long! But now I miss them.$4#$b#Isn't that funny?$10",
+
+"summer_Sun8":"It's been wonderful getting to know you @. I feel like I can be perfectly honest with you.
+#$q 124/125 Little_Followup#I don't like being a big kid, I wanna go back to being a little boy.
+#$r 124 0 Little_Little#Awww, Sam. You ARE just a little boy!
+#$r 125 0 Little_Little#Looks like I'm going to need some more diapers for the little boy.
+#$r 124 0 Little_Excited#Yeah, being big is gross. We should play together!
+#$r 125 0 Little_Excited#I'll change your diapers if you change mine.
+",
+"Little_Little": "Uh huh!$3#$b#%Sam squeals happily and hides his blushing face.", 
+"Little_Excited": "Yeah!$3#$b#%Sam squeals happily and hides his blushing face.", 
+"Little_Followup":"#$p 124#You always make me feel so little. It means so much to me, thank you.$4|I really want to go back to diapers full time.$4#$b#I just don't think I can while I'm still living with Mommy.$10",
+
+"fall_Tue4": "Hi, @. Do you want to hang out or something?#$e#I could show you my favorite stuffy.$1#$b#He's a worm and I named him Mr. Wiggles!$10",
+"fall_Thu6_1": "I think my Daddy might be coming back next year.#$e#I guess that's kind of soon. Weird.",
+"fall_Thu6": "I guess I should start thinking about moving out soon...$s#$e#...But I would miss Mommy's fish casserole, so I dunno...$s#$e#I hate making decisions.",
+"fall_Sat4":"After Vincent was born, things felt different.$7#$e#I missed the attention I used to get. I guess I still do.$9",
+"fall_Mon2":"I can't believe I have a job...$2
+#$q 120/121 Job_Followup#It almost feels like I'm not old enough yet.
+#$r 120 0 Job_Ready#You just need a little more time before you're ready.
+#$r 120 0 Job_Pretend#You could always just stop pretending to be a big boy. 
+",
+"Job_Ready": "Yeah, I guess I do, but I'm supposed to be responsible for Mommy...$9#$b#I mean Mom...$8", 
+"Job_Pretend": "Man I wish. It'd be so much better to just play all day. Just like Vincent.$4#$b#He doesn't have to work.$5", 
+"Job_Followup":"#$p 120#It felt good to admit I wasn't ready. Thank you.$3|I wonder if I should skip a day and just play in the forrest all day!$1",
+
+"fall_Mon8":"#$p 102#@! Mommy got freezy pops for us! Score!$1|We watched a movie as a family last night.$7#$b#Vincent messed his diaper right at the beginning, but since he didn't seem bothered Mommy waited until the movie ended to change him.#$e#I wanted to be in his shoes.$4",
+
+"fall_Wed6":"Can I share a secret with you?$7
+#$q 122/123 Diapers_Followup#I've never told this to anybody, but I really want to go back to wearing diapers.
+#$r 122 0 Diapers_Nice#Awww, you're such a precious little boy.
+#$r 123 0 Diapers_Join#Really?! Me too! 
+",
+"Diapers_Nice": "R-Really?!$10%Sam is so overwhelmed he starts to tear up a little. You hold him close and rub his back until he calms down.#$e#T-Thanks @.$4%Sam looks like a huge weight's been lifted off his shoulders.", 
+"Diapers_Join": "Really?! For real?! You'd look so cute in one @! We could be diaper buddies!$10#$e#Man it feels weird being able to say that out loud to somebody.$4", 
+"Diapers_Followup":"I used to wet the bed until I was a teenager.$9#$b#I was embarrassed about needing diapers at night for so long! But now I miss them.$4#$b#Isn't that funny?$10",
+
+"fall_Fri8":"It's been wonderful getting to know you @. I feel like I can be perfectly honest with you.
+#$q 124/125 Little_Followup#I don't like being a big kid, I wanna go back to being a little boy.
+#$r 124 0 Little_Little#Awww, Sam. You ARE just a little boy!
+#$r 125 0 Little_Little#Looks like I'm going to need some more diapers for the little boy.
+#$r 124 0 Little_Excited#Yeah, being big is gross. We should play together!
+#$r 125 0 Little_Excited#I'll change your diapers if you change mine.
+",
+"Little_Little": "Uh huh!$3#$b#%Sam squeals happily and hides his blushing face.", 
+"Little_Excited": "Yeah!$3#$b#%Sam squeals happily and hides his blushing face.", 
+"Little_Followup":"#$p 124#You always make me feel so little. It means so much to me, thank you.$4|I really want to go back to diapers full time.$4#$b#I just don't think I can while I'm still living with Mommy.$10",
+
+"winter_Tue4": "Hi, @. Do you want to hang out or something?#$e#We could make a snow fort!$1",
+"winter_Thu6_1": "I think my Daddy is coming back this spring.#$e#It's been 3 years since I've seen him. This is going to be strange.",
+"winter_Thu6": "Daddy's been back for a while now. I guess I'm finally getting used to it.",
+"winter_Thu8":"We watched a movie as a family last night.$7#$b#Vincent fell asleep right away, so he wasn't in Mommy's lap like he usually is.#$b#I was sort of leaning against her shoulder, and she patted her lap so I laid my head down in it...$4#$b#It felt silly at first, but she pet my hair a lot and that was nice.$4#$e#I felt like her special little boy again.$10",
+"winter_Mon2":"I can't believe I have a job...$2
+#$q 120/121 Job_Followup#It almost feels like I'm not old enough yet.
+#$r 120 0 Job_Ready#You just need a little more time before you're ready.
+#$r 120 0 Job_Pretend#You could always just stop pretending to be a big boy. 
+",
+"Job_Ready": "Yeah, I guess I do, but I'm supposed to be responsible for Mommy...$9#$b#I mean Mom...$8", 
+"Job_Pretend": "Man I wish. It'd be so much better to just play all day. Just like Vincent.$4#$b#He doesn't have to work.$5", 
+"Job_Followup":"#$p 120#You're right, I don't think I'm quite ready to be a grown up yet.$4|I wonder if I should skip a day and just play in the snow all day!$1",
+
+"winter_Wed6":"Can I share a secret with you?$7
+#$q 122/123 Diapers_Followup#I've never told this to anybody, but I really want to go back to wearing diapers.
+#$r 122 0 Diapers_Nice#Awww, you're such a precious little boy.
+#$r 123 0 Diapers_Join#Really?! Me too! 
+",
+"Diapers_Nice": "R-Really?!$10%Sam is so overwhelmed he starts to tear up a little. You hold him close and rub his back until he calms down.#$e#T-Thanks @.$4%Sam looks like a huge weight's been lifted off his shoulders.", 
+"Diapers_Join": "Really?! For real?! You'd look so cute in one @! We could be diaper buddies!$10#$e#Man it feels weird being able to say that out loud to somebody.$4", 
+"Diapers_Followup":"I used to wet the bed until I was a teenager.$9#$b#I was embarrassed about needing diapers at night for so long! But now I miss them.$4#$b#Isn't that funny?$10",
+
+"winter_Sat8":"It's been wonderful getting to know you @. I feel like I can be perfectly honest with you.
+#$q 124/125 Little_Followup#I don't like being a big kid, I wanna go back to being a little boy.
+#$r 124 0 Little_Little#Awww, Sam. You ARE just a little boy!
+#$r 125 0 Little_Little#Looks like I'm going to need some more diapers for the little boy.
+#$r 124 0 Little_Excited#Yeah, being big is gross. We should play together!
+#$r 125 0 Little_Excited#I'll change your diapers if you change mine.
+",
+"Little_Little": "Uh huh!$3#$b#%Sam squeals happily and hides his blushing face.", 
+"Little_Excited": "Yeah!$3#$b#%Sam squeals happily and hides his blushing face.", 
+"Little_Followup":"#$p 124#You always make me feel so little. It means so much to me, thank you.$4|I really want to go back to diapers full time.$4#$b#I just don't think I can while I'm still living with Mommy.$10",
+
+			}
+		},
+		
+		{
+			"LogName":"Sam Marriage",
+			"Action":"EditData",
+			"Target":"Characters/Dialogue/MarriageDialogueSam",
+			"Entries":{
+				
+  "Rainy_Day_0": "%Sam is staring out the window, watching the rain roll down wearing just his soggy night diaper and pajama shirt.#$e#%He doesn't seem to notice you. He bends his knees slightly, gently pushing a soft mess into his diaper without a second though. Only then do you tap his shoulder.#$b#@!8#$b#I-I was just watchin' the rain$10.",
+  "Rainy_Day_1": "Sebastian loves this kind of weather. When we were little we used to go frog catching when it rained.#$e#Do you wanna go catch frogs?!$1",
+  "Rainy_Day_2": "Hey, I found one of these rolling around in the back of a drawer. [90 88 86 535]#$e#I thought you might be able to use it.",
+  "Rainy_Day_3": "Aw, man. These cloudy days are kind of a drag...$7#$e#We could just play inside all day.#$b#$y 'Maybe we can cuddle and watch some cartoons._You'll need to wear a second diaper this time._I didn't leak THAT much last time!$1_You'll have to change me first!_Awww, but I'll miss out on all the squishing.$10'",
+  "Rainy_Day_4": "How'd you sleep? The sound of rain really makes me zonk.#$e#I woke up wet too, but I don't remember waking up to pee.$4#$b#That rain really works on me, huh!$10",
+  "patio_Sam": "*Sigh*... I'm never gonna land this trick...$s",
+  "Rainy_Night_0": "Hey, how was your day? I just layed around and read comics most of the day... it was great.$1#$b#What? N-no, I don't need a change!$8#$e#%It is obvious Sam is in a stinky diaper.",
+  "Rainy_Night_1": "It was a pretty low-key day for me... colas, frozen pizza, a few hours noodling around with a coloring book. I feel relaxed.#$e#%Sam proves his point by sighing and flooding his diaper in front of you, blushing softly.",
+  "Rainy_Night_2": "Earlier, I listened to our live recording from that show we played. Remember that? Man, was that sloppy.#$b#It made me a little nervous that you were there, I didn't want to mess up and have you think I was a loser!$10",
+  "Rainy_Night_3": "#$p 102#I hope Vincent's not too lonely now that I'm gone... I kinda felt responsible for the little guy.$s|I hope Vincent's not too lonely now that I'm gone... I kinda felt responsible for the little guy.$s#$e#I bet he'd get a kick out of how much of a little guy I turned out to be!$10.Sometimes I like to imagine being little like this right along side him. Having Mommy change our diapers together.$4#$e#I doubt I could ever fill a diaper as good as he can!$10",
+  "Rainy_Night_4": "Hey, I tossed a couple frozen pizzas into the oven. Here's yours. [206]$h#$e#%Sam sits down to eat with an audible squish. He doesn't seem concerned about it.",
+  "Indoor_Day_0": "Phew... I'll tell you one thing I don't miss about my old life... working at JojaMart.#$e#Did I ever tell you how embarrassed I got every time I had to work in the diaper isle?$10#$e#One time I found an open package, and instead of throwing it out I hid it for later.$4#$e#I was so nervous, but I'm glad I did it! That was a fun week.$10",
+  "Indoor_Day_1": "Hey, I made you some instant pancakes. Enjoy. [211]$h#$e#What? I never learned to cook... Mommy always did that.#$e#I miss her a lot actually$2",
+  "Indoor_Day_2": "Good morning @.#$b#$y 'Sam is obviously in need of a diaper change._Common little boy, let's go take care of that diaper._Y-yeah, Okay!_Hmmm._I think that should hold until after breakfast._%Sam just blushes and nods, reaching his hand down to feel how squishy his diaper is.'",
+  "Indoor_Day_3": "Uhhmmmm, @? C-can I show you something?$4#$e#%Sam presses your hand into his diaper front. It's still dry, but not for long.#$b#Sam sighs as you feel the warmth spread across your hand. You give it a good squish just to watch him squirm.",
+  "Indoor_Day_4": "Um... Maybe I'll help out on the farm some other day. I feel lazy today.$1#$e#%Sam wiggles his crinkly bottom at you before scampering off to find his coloring book.",
+  "Indoor_Night_0": "Hey, you look tired. Let me help you relax tonight, okay? Maybe I'll give you a massage later.#$e$I owe you that much for taking care of my diapers all the time!$10",
+  "Indoor_Night_1": "My day?$8#$b#Oh... I can hardly remember. I didn't really do anything of note. Just relaxed and had a good time.$3#$b#It doesn't take long to notice Sam's leaking diaper he was trying to sneak by you.",
+  "Indoor_Night_2": "Hey, sorry I didn't make the bed. You know I'm sloppy... that's why you like me, right?$h#$b#You notice Sam's messy diaper just before he plops down on it with an audible squish.",
+  "Indoor_Night_3": "#$p 102#The only thing I miss about living at home is Mommy's fish casserole. And Mommy... I miss my Mommy$9|As much as I love being open about my diapers with you, I kind of miss the naughty rush of nabbing one of Vincent's.#$b#Or being sneaky while watching Vincent get changed.$4#$e#Is it weird to miss wanting the thing you finally have?$10",
+  "Indoor_Night_4": "Ready to hit the hay? I got all the diaper supplies laid out all by myself this time!$3#$e# I love you so much.$4",
+  "Outdoor_0": "Maybe I should get some off-road wheels for my skateboard. Mayor Lewis can't touch me out here.$h",
+  "Outdoor_1": "I still get nervous about my diapers crinkling when I'm off the farm.#$e#At least I don't have to worry about that here!$1",
+  "Outdoor_2": "Hi, @! If I knew more about farm work I'd help you out more. Sorry!#$e#It makes me feel like a helpless little Daddy's boy!$3^It makes me feel like a helpless little Momma's boy!$3",
+  "Outdoor_3": "Something in the air makes me feel positive... maybe it's the faint whiff of pizza from Gus' ovens.#$b#%Wait... That smell's not pizza.$10",
+  "Outdoor_4": "Wow... you look great today, and the specks of mud just add some extra charm.$l",
+  "OneKid_0": "I'll change %kid1's diaper... don't worry about it. You've already done your fair share of changing diapers!$10",
+  "OneKid_1": "It's weird, but I really like being a father!$h#$e#I feel like all of our little time together prepaired me for how much playing babies need to do!",
+  "OneKid_3": "I think we should have another kid. Why stop now?",
+  "TwoKids_0": "I woke up early, fed the kids and changed their diapers! We're all set. You can just focus on raking in that sweet money.$h#$e#I'm just kidding... I didn't marry you for the money. Though the diaper budget has certainly gone up.",
+  "TwoKids_1": "We have to make sure and give %kid1 a lot of attention now that we have %kid2. We don't want any jealousy between them.#$e#I know how jealous I always felt about Vincent...$9",
+  "TwoKids_2": "It's fun to see the babies playing with each other. I think they're going to be very close.",
+  "TwoKids_3": "I never thought I'd become such a family man, but I'm really satisfied with what we've built here. Life is going great.$h",
+  "Good_1": "Do you ever think of that night we snuck into my room? I do, often...$l#$b#It was the first time I wore diapers around anyone else.$4",
+  "Good_2": "You know, I think I had a feeling we'd be together from the very beginning. There's just something special between us.$l#$b#I spent so much time fantasizing about being the farmer's little boy, and now it's a reality!$1",
+  "Good_3": "%Sam tugs on your sleeve bashfully.#$b#Uhmmmm, @? Can you change me please?$4#$e#Sam looks even more embarrassed as you give him a thorough check, just to make sure he really needs one.",
+  "Good_6": "Be careful out there! I know you go into the caves sometimes... you could be eaten alive in there!#$e#And my diaper would never get changed again and I would drown.$8#$b#Yup, that's what would happen.$1",
+  "Good_4": "%Sam is giggling to himself while playing with a jingly toy. You decide to give a quick diaper check while he's distracted.#$b#H-hey!$8#$e#He definitely needs a change.",
+  "Good_5": "I wanna show you something!$3#$b#Sam holds up a crayon drawing of both of you smiling on the farm.#$e#Do you love it?!$1",
+  "funLeave_Sam": "I'm gonna visit the family today, okay? I'll be home in the evening.",
+  "funReturn_Sam": "#$p 102#Seeing my family today was nice. I didn't realize just how much I missed my Mommy$4|I saw my family today, and I decided to wear my diapers. I don't think anyone noticed.#$b#I've been in them for so long here that I was afraid I'd have an accident if I didn't.$10#$e#Vincent was the same proud little diaper boy he always is.#$b#It was fun getting to play with him while we were both in diapers.",
+  "spring_1": "Ub... spring... my doze... allergies.$s",
+  "spring_12": "Are you excited for tomorrow's festival? It'll be cool to see Sebastian again.",
+  "spring_23": "Oh... tomorrow's the flower dance, isn't it? I thought I could get out of it now that we're married.#$e#Whatever. I guess it's funny in a weird way, especially now that I'm going to be waddling the whole time.$1",
+  "summer_1": "The pollen count is a little lower in summer, so my nose is really happy.$h",
+  "summer_10": "Have you thought about what you're going to put in the luau soup?#$e#It might be funny to put something nasty. You know, to play a prank on the governor!$h#$e#Sorry...",
+  "summer_27": "Summer's great, but I'm ready for the fall now.#$e#Should we watch the jellyfish tomorrow night? It's always kind of fun.",
+  "fall_1": "It seems like the whole valley's changed overnight... I guess fall's finally here.",
+  "fall_15": "Hey, tomorrow's the fair. I need to get my old slingshot wrist back in shape...",
+  "fall_26": "I wonder if Mommy will let Vincent enter the haunted maze this year. Probably not...$h#$e#Poor kid. He's gonna have to grow up some day...#$e#Well...Maybe not. I sure didn't!$10",
+  "winter_1": "The cold air makes my diapers feel even more warm and cozy. It's pretty wonderful.$1",
+  "winter_7": "Are we going to stop by the ice festival tomorrow? It might be fun to see everyone again...",
+  "winter_28": "We had a great year, @... it's kind of sad that it's over.#$e#We'll just have to make next year even better!$h",
+			}
+		}	
+	]
+}

--- a/Regression Dialogue/Dialogue/NPCs/Sebastian.json
+++ b/Regression Dialogue/Dialogue/NPCs/Sebastian.json
@@ -1,0 +1,21 @@
+{
+	"Changes":[
+		{
+			"LogName":"Sebastian",
+			"Action":"EditData",
+			"Target":"Characters/Dialogue/Sebastian",
+			"Entries":{
+
+
+				"Mon8":"#$q 305/306 diaperquestion_followup#This might be an awkward question...#$b#Do you actually NEED your diapers?#$r 305 -10 diaperquestion_yes#... Yeah, I do...#$r 305 10 diaperquestion_yes#Yeah, I need them for my accidents.#$r 306 10 diaperquestion_no#Nope, I just like them.",
+				"diaperquestion_yes":"Oh...#$b#Well I hope you're not too embarassed.#$b#I think it's kind of cute actually.$4",
+				"diaperquestion_no":"Really?#$b#I thought that might have been the case#$e#Wow$4",
+				"diaperquestion_followup":"#$p 306#Your diapers make you look like such a little boy.$1^Your diapers make you look like such a little girl.$1|I hope I didn't make you upset when I asked about your diapers.$2",
+				
+				
+		
+
+			}
+		},	
+	]
+}

--- a/Regression Dialogue/Dialogue/NPCs/Vincent.json
+++ b/Regression Dialogue/Dialogue/NPCs/Vincent.json
@@ -1,0 +1,70 @@
+{
+	"Changes":[
+		{
+			"LogName":"Vincent",
+			"Action":"EditData",
+			"Target":"Characters/Dialogue/Vincent",
+			"Entries":{				
+  "Introduction": "Oh, a stranger! My name's Vincent.#$b#Mommy says not to talk to strangers... But you seem okay.
+  #$q 101/102 ABDLChild_fallback#%Would you be comfortable seeing ABDL dialogue from Vincent and Jas?
+  #$r 101 0 ABDLChild_Yes#Yes, I am comfortable with that.
+  #$r 102 0 ABDLChild_No#No, I would like to see the original dialogue.",
+  //-----------------
+  "ABDLChild_Yes":"%The more hearts you have with them the more ABDL dialogue there will be.",
+  "ABDLChild_No":"%Okay. All the original lines will be unchanged, and they also won't notice you using your pants.",
+  "ABDLChild_fallback":"#$p 102#What's your name?|%You hear a crinkle with each step Vincent takes.",
+  //The question above happens during the introduction of Vincent or Jas, whomever the player interacts with first. They'll get to choose whether or not they want ABDL dialogue for the two of them. 
+  //Unfortunately, this only works for new farms, not if a player installs the mod and loads an old save where they've already met both Vincent and Jas. Then it defaults to the ABDL text.
+
+  
+  "spring_12": "The egg hunt is tomorrow! I'm gonna find so many!$1#$e#I'm a good finder.",
+  "spring_Mon10":"#$p 102#I wanna be just like my big brother when I grow up!|I think I need my diaper changed, but I'm gonna wait until Mommy checks me.#$e#I don't mind being messy a bit longer!$1",
+  "spring_Tue":"#$p 102#*sigh*... Mommy won't let me have any more gummies today.$s|I like it better when Miss Penny reads to us.",
+  "spring_Tue10":"#$p 102#Don't tell Mommy... but you're my favorite grown-up.$h|I found a frog and put it in my diaper.#$b#It's a surprise for mommy!$1#$e#%Vincent looks like he's being tickled.",
+  "spring_Wed2":"#$p 102#I wanna look for bugs, but Mommy gets mad when I'm all dirty.$u|Mommy told me I can still be her little baby boy if I wasn't ready to grow up yet.#$e#I love my Mommy!$1",
+  "spring_Thu":"#$p 102#I'm hungry... where's Mommy?$s|%You notice Vincent's diaper peeking out of his waistband.#$e#Hi @!$1",
+  "spring_Thu6":"#$p 102#You're not as boring as most grown-ups!|%You notice Vincent's diaper peeking out of his waistband.#$b#%When he sees you he giggles and pats his crinkly bottom.",
+  "spring_Thu10":"#$p 102#You're not as boring as most grown-ups!|%You notice Vincent's diaper peeking out of his waistband.#$b#%When he sees you he giggles and pats his crinkly bottom.#$e#%You just barely notice a squish.",
+  "spring_Fri2":"#$p 102#Oh no... Mommy's making lentil soup tonight.$s|Sam says I'm still his cute little baby brother.#$e#%Vincent wiggles in glee.",
+  "spring_Fri_inlaw_Sam":"#$p 102#Oh no... Mommy's making lentil soup tonight.$s|How's my brother doing?#$e#Can you tell him he can still borrow my stuffies if he wants?$3#$b#I don't want him to be scared.$2",
+  "spring_Sat8":"#$p 102#Miss Penny makes me read a new book every week.$s|Jas pooped in her pull ups at the library yesterday!#$e#She blamed it on me and Ms. Penny believed her.$2#$e#I was pretty messy though.$3",
+  "spring_Sun4":"#$p 102#Hi there!|I can tie my own shoes now, but sometimes I ask Mommy to do it for me anyway.#$e#I like how it makes her all smiley!$1",
+
+  "summer_Mon4":"#$p 102#I wanna be just like my big brother when I grow up!|Jas only pretends to be a big girl.$3",
+  "summer_Mon8":"#$p 102#I wanna be just like my big brother when I grow up!|Jas only pretends to be a big girl.$3#$e#Pull ups are basically just diapers anyway.",
+  "summer_Tue":"#$p 102#*sigh*... Mommy won't let me have any more gummies today.$s|My teddy bear's name is Squishy.#$e#I like him a lot!$1",
+  "summer_Tue_inlaw_Penny":"#$p 102#*sigh*... Mommy won't let me have any more gummies today.$s|Does Miss Penny change your diapers too?#$e#She says I gotta try and use the potty more, but if I do she won't change me anymore.$2",
+  "summer_Wed10":"#$p 102#I wanna look for bugs, but Mommy gets mad when I'm all dirty.$u|@! I wanna show you something cool!#$e#%Vincent squats down shamelessly, grunting softly while you watch his pants droop.#$e#All done!$1",
+  "summer_Thu6":"#$p 102#You're not as boring as most grown-ups!|Mommy wants me to try using the potty, but I don't wanna.$3#$b#It's scary, and I don't wanna be a big kid yet.$2",
+  "summer_Fri2":"#$p 102#Ew, it's boiled beet night again...$s|%Vincent is sucking on his thumb and humming happily to himself.#$e#Hi @!$1",
+  "summer_Fri10":"#$p 102#I wanna look for bugs, but Mommy gets mad when I'm all dirty.$u|%Vincent is sucking on his thumb and humming happily to himself.#$e#%You notice him pause for a minute, his free hand resting on his diaper, a faint blush on his cheeks, and a little grin behind his thumb.#$e#Ahhhh.",
+  "summer_Sat10":"#$p 102#Don't tell Mommy... but you're my favorite grown-up.$h|I found a frog and put it in my diaper.#$b#It's a surprise for mommy!$1#$e#%Vincent looks like he's being tickled.", 
+  "summer_Sun2":"#$p 102#Miss Penny makes me read a new book every week.$s|Sometimes, when I'm bored, I like to play with my old baby toys.",
+  
+  "fall_Mon4":"#$p 102#I wanna be just like my big brother when I grow up!|Jas keeps bragging about being in pull ups.#$e#I miss when we were in diapers together.$2",
+  "fall_Tue10":"#$p 102#*sigh*... Mommy won't let me have any more gummies today.$s|Wanna know a secret?#$e#I don't wanna stop wearing diapers.$3#$e#Mommy says it's okay if I'm not ready yet!$1",
+  "fall_Wed":"#$p 102#I wanna look for bugs, but Mommy gets mad when I'm all dirty.$u|%You notice Vincent's diaper peeking out of his waistband.", 
+  "fall_Wed6":"#$p 102#I wanna look for bugs, but Mommy gets mad when I'm all dirty.$u|%You notice Vincent's diaper peeking out of his waistband.#$b#%When he sees you he giggles and pats his crinkly bottom.",
+  "fall_Wed10":"#$p 102#I wanna look for bugs, but Mommy gets mad when I'm all dirty.$u|%You notice Vincent's diaper peeking out of his waistband.#$b#%When he sees you he giggles and pats his crinkly bottom.#$e#%You just barely notice a squish.",
+  "fall_Thu10":"#$p 102#You're not as boring as most grown-ups!|I think I need my diaper changed, but I'm gonna wait until Mommy checks me.#$e#I don't mind being messy a bit longer!$1",
+  "fall_Fri4":"#$p 102#Oh no... Mommy's making lentil soup tonight.$s|I can tie my own shoes now, but sometimes I ask Mommy to do it for me anyway.#$e#I like how it makes her all smiley!$1",
+  "fall_Sat6":"#$p 102#Miss Penny makes me read a new book every week.$s|Mommy told me I can still be her little baby boy if I wasn't ready to grow up yet.#$e#I love my Mommy!$1",
+  "fall_Sun4":"#$p 102#Hi there!|Sam says I'm still his cute little baby brother.#$e#%Vincent wiggles in glee.",
+  "fall_Sun_inlaw_Sam":"#$p 102#Hi there!|How's my brother doing?#$e#Can you tell him he can still borrow my stuffies if he wants?$3#$b#I don't want him to be scared.$2",
+
+  "winter_Mon":"#$p 102#I wanna be just like my big brother when I grow up!|Jas only pretends to be a big girl.",
+  "winter_Mon8":"#$p 102#I wanna be just like my big brother when I grow up!|Jas only pretends to be a big girl.$3#$e#Pull ups are basically just diapers anyway.", 
+  "winter_Tue10":"#$p 102#*sigh*... Mommy won't let me have any more gummies today.$s|%Vincent stares off for a moment and sighs in relief as a faint hiss reaches your ears.#$e#Just warmin' up!$1",
+  "winter_Wed2":"#$p 102#I wanna look for bugs, but Mommy gets mad when I'm all dirty.$u|%Vincent is sucking on his thumb and humming happily to himself.#$e#Hi @!$1",
+  "winter_Wed10":"#$p 102#I wanna look for bugs, but Mommy gets mad when I'm all dirty.$u|%Vincent is sucking on his thumb and humming happily to himself.#$e#%You notice him pause for a minute, his free hand resting on his diaper, a faint blush on his cheeks, and a little grin behind his thumb.#$e#Ahhhh",
+  "winter_Thu8":"#$p 102#You're not as boring as most grown-ups!|Mommy wants me to try using the potty, but I don't wanna.$3#$b#It's SO cold!$2",
+  "winter_Fri":"#$p 102#Oh no... Mommy's making lentil soup tonight.$s|Sam said he'd make a snow man with me today!#$e#We're gonna have hot chocolate after too.",
+  "winter_Sat10":"#$p 102#Don't tell Mommy... but you're my favorite grown-up.$h|@! I wanna show you something cool!#$e#%Vincent squats down shamelessly, grunting softly while you watch his pants droop.#$e#All done!$1",
+  "winter_Sun":"#$p 102#Miss Penny makes me read a new book every week.$s|My teddy bear's name is Squishy.#$e#I like him a lot!$1",
+  "winter_Sun_inlaw_Penny":"#$p 102#Miss Penny makes me read a new book every week.$s|Does Miss Penny change your diapers too?#$e#She says I gotta try and use the potty more, but if I do she won't change me anymore.$2",
+
+  
+			},
+		},
+	]
+}

--- a/Regression Dialogue/manifest.json
+++ b/Regression Dialogue/manifest.json
@@ -1,0 +1,11 @@
+{
+  "Name": "Regression Dialogue",
+  "Author": "Various",
+  "Version": "1.0.0",
+  "Description": "More dialoge for the regression mod",
+  "UniqueID": "Regression_Dialogue",
+  "UpdateKeys": [],
+  "ContentPackFor": {
+    "UniqueID": "Pathoschild.ContentPatcher"
+  }
+}

--- a/Regression/en.json
+++ b/Regression/en.json
@@ -1,5 +1,5 @@
 ﻿{
-	"Jodi_Initial_Letter": [ "Dear @,^Welcome to town! Here are some veggies from the garden to tide you over while you move in! Also, I feel it's important to note that there's an... odd effect around here. You'll see what I mean soon enough, probably, but I've still enclosed some supplies. Visit Pierre if you run out.^      <, Jodi" ],
+	"Jodi_Initial_Letter": [ "Dear @,^Welcome to town! Here are some veggies from the garden to tide you over while you move in. Your grandpa told me about your little problem, so I enclosed some supplies for you. Visit Pierre if you run out!^      <, Jodi" ],
 	"Food_Low": [
 		"You're hungry.",
 		"Your stomach rumbles.",
@@ -35,11 +35,11 @@
 	"Bladder_Orange": [
 		"You really need to pee!",
 		"You're not sure how much longer you can hold your pee!",
-		"If you don't find somewhere to pee soon, you'll pee yourself!",
+		"If you don't pee soon, you'll have an accident!",
 		"You start crossing your legs trying not to pee yourself!"
 	],
 	"Bladder_Red": [
-		"You start to panic! You're about to pee yourself!",
+		"You can’t hold it anymore! You're about to pee yourself!",
 		"You have to pee so badly you start hopping around!",
 		"You feel a few drops of pee leak out into your $UNDERWEAR_NAME$!"
 	],
@@ -56,20 +56,20 @@
 	],
 	"Bowels_Red": [
 		"You can feel the poop starting to push out!",
-		"You start to panic! You're about to mess yourself!"
+		"You can’t hold it anymore! You're about to mess yourself!"
 	],
-	"Bladder_Continence_Yellow": [ "You notice you seem to be getting worse at holding your pee." ],
-	"Bladder_Continence_Orange": [ "You notice that you're getting pretty bad at holding your pee." ],
-	"Bladder_Continence_Red": [ "You notice that you're getting close to being unable to hold your pee." ],
-	"Bladder_Continence_Min": [ "You notice that you're almost totally unable to hold your pee." ],
-	"Bowel_Continence_Yellow": [ "You notice you seem to be getting worse at holding your poop." ],
-	"Bowel_Continence_Orange": [ "You notice that you're getting pretty bad at holding your poop." ],
-	"Bowel_Continence_Red": [ "You notice that you're getting close to being unable to hold your poop." ],
-	"Bowel_Continence_Min": [ "You notice that you're almost totally unable to hold your poop." ],
+	"Bladder_Continence_Yellow": [ "You seem to be getting worse at holding your pee." ],
+	"Bladder_Continence_Orange": [ "You're getting pretty bad at holding your pee." ],
+	"Bladder_Continence_Red": [ "You're getting close to being unable to hold your pee." ],
+	"Bladder_Continence_Min": [ "You're almost totally unable to hold your pee." ],
+	"Bowel_Continence_Yellow": [ "You seem to be getting worse at holding your poop." ],
+	"Bowel_Continence_Orange": [ "You're getting pretty bad at holding your poop." ],
+	"Bowel_Continence_Red": [ "You're getting close to being unable to hold your poop." ],
+	"Bowel_Continence_Min": [ "You're almost totally unable to hold your poop." ],
 	"Pee_Voluntary": [
-		"You undress and spray your pee freely onto the ground.",
-		"Undressing, you take a deep breath and pee on the ground.",
-		"Looking around sheepishly, you pull your pants down and go number one right where you are!",
+		"You drop your $UNDERWEAR_NAME$ and pee on the ground.",
+		"Moving your $UNDERWEAR_NAME$, you take a deep breath and empty your bladder.",
+		"Looking around sheepishly, you pull your $UNDERWEAR_NAME$ down and go right where you are!",
 		"You slide your $PANTS_NAME$ to your knees</, squat,> and let your pee splatter all over the ground.",
 		"You pull down your $PANTS_NAME$ and sprinkle on the ground.",
 		"You pull your $PANTS_NAME$ down and go <pee pee/tinkle> on the ground.",
@@ -80,7 +80,7 @@
 		"Looking around nervously, you pull your $PANTS_NAME$ down and go number two right on the ground!",
 		"Undressing, you squat and let your poop pile out onto the ground.",
 		"You pull down your $PANTS_NAME$ and poop on the ground.",
-		"You slide your $PANTS_NAME$ to your knees, squat down, and strain a bit to force your poop out."
+		"You slide your $PANTS_NAME$ to your knees, squat down, and gently push all your poop out."
 	],
 	"Pee_Toilet": [
 		"Sprinkling into the toilet, you breathe a sigh of relief.",
@@ -88,7 +88,7 @@
 		"You slide your $PANTS_NAME$ down, <stand in front of the toilet/sit on the toilet>, and pee like a big <boy/girl>.",
 		"You barely make it to the toilet. Any longer and you might have wet yourself!",
 		"You wee in the toilet. Good thing you were able to hold it until then!",
-		"You proundly pee in the toilet. Now you won't need a diaper!",
+		"You proudly pee in the toilet. Now you won't need a diaper!",
 		"You tinkle in the toilet. Your mommy would be proud!",
 		"You undress and go number one in the toilet like a good <boy/girl>."
 	],
@@ -115,12 +115,12 @@
 		"You relax your bladder and pee gushes into your $UNDERWEAR_NAME$.",
 		"Your bladder tingles as you let go and warmth spreads out into your $UNDERWEAR_NAME$.",
 		"You take a deep breath and release your pee into your $UNDERWEAR_NAME$.",
-		"You glance around a little sheepishly and pee your $UNDERWEAR_NAME$ like a little <boy/girl>."
+		"You glance around a little sheepishly as you deliberately pee your $UNDERWEAR_NAME$ like a little <boy/girl>."
 	],
 	"Mess_Voluntary": [
 		"You squat a little and empty your bowels into your $UNDERWEAR_NAME$.",
 		"You concentrate and push a warm load of poop into your $UNDERWEAR_NAME$.",
-		"You hope nobody notices as you let a big poop squeeze out into your $UNDERWEAR_NAME$."
+		"You hope nobody notices as you deliberately let a big poop squeeze out into your $UNDERWEAR_NAME$."
 	],
 	"Pee_Attempt": [
 		"You pull down your $PANTS_NAME$ and relax your bladder, but nothing comes out.",
@@ -139,55 +139,55 @@
 		"You try to mess in your $UNDERWEAR_NAME$, but you can't."
 	],
 	"Still_Soiled": [
-		"You feel your <wet&messy> $UNDERWEAR_NAME$ getting a bit cold.",
-		"You feel humiliated knowing that you're still in $UNDERWEAR_PREFIX$ <wet&messy> $UNDERWEAR_NAME$.",
-		"You blush realizing you're wearing $UNDERWEAR_PREFIX$ <wet&poopy> $UNDERWEAR_NAME$.",
-		"You smell something stinky and realize you're still wearing $UNDERWEAR_PREFIX$ <wet&messy> $UNDERWEAR_NAME$.",
-		"You feel your <wet&poopy> $UNDERWEAR_NAME$ squishing between your legs.",
-		"You notice your <wet&messy> $UNDERWEAR_NAME$ <is#are> sagging.",
+		"You feel your <wet&messy> $UNDERWEAR_NAME$ and blush at the sensation.",
+		"You feel like a little <boy/girl> knowing that you're still in $UNDERWEAR_PREFIX$ <wet&messy> $UNDERWEAR_NAME$.",
+		"You blush and smile warmly realizing you're wearing $UNDERWEAR_PREFIX$ <wet&poopy> $UNDERWEAR_NAME$.",
+		"You smell something stinky and your heart flutters as you realize you're still wearing $UNDERWEAR_PREFIX$ <wet&messy> $UNDERWEAR_NAME$.",
+		"You feel your <wet&poopy> $UNDERWEAR_NAME$ squishing between your legs and smile to yourself.",
+		"You notice your sagging <wet&messy> $UNDERWEAR_NAME$ <is#are> snug and warm.",
 		"You notice you're waddling because your $UNDERWEAR_NAME$ <is#are> <wet&messy>.",
-		"You're uncomfortable in your <wet&messy> $UNDERWEAR_NAME$ and need to change soon.",
-		"You feel your dirty $UNDERWEAR_NAME$. You can't believe you <wet&messed> <it#them> like a little baby!",
+		"You consider changing your <wet&messy> $UNDERWEAR_NAME$ soon, but not right now. It's still warm",
+		"You press your hand into your squishy $UNDERWEAR_NAME$. You feel like a little baby knowing you <wet&messed> <it#them>.",
 		"You feel your $UNDERWEAR_NAME$. <It's#They're> all <wet&messy>!"
 	],
 	"Wet_Accident": [
-		"You bite your lip and whimper as your bladder gives in and you flood your $UNDERWEAR_NAME$.",
-		"You whimper helplessly as pee streams into your $UNDERWEAR_NAME$.",
+		"You bite your lip and take a sharp breath through your nose as your bladder gives in and you flood your $UNDERWEAR_NAME$.",
+		"You're helpless as pee streams into your $UNDERWEAR_NAME$.",
 		"You hope no one notices the pee pouring into your $UNDERWEAR_NAME$.",
-		"Turning bright red, you suddenly feel warmth spreading into your $UNDERWEAR_NAME$!",
-		"You desperately hope your $UNDERWEAR_NAME$ doesn't leak as you involuntarily wet yourself.",
-		"You stand paralyzed as you start to go <wee/tinkle> in your $UNDERWEAR_NAME$!",
-		"Turning red, you realize the warmth spreading into your crotch is pee!",
+		"Your thumb finds its way into your mouth as you suddenly feel warmth spreading into your $UNDERWEAR_NAME$!",
+		"You hope your $UNDERWEAR_NAME$ doesn't leak as you realize you're wetting yourself.",
+		"You stop in your tracks as you start to go <wee/tinkle> in your $UNDERWEAR_NAME$!",
+		"You give a sheepish smile as you realize the warmth spreading into your crotch is pee!",
 		"You <gasp/squeal> when you realize you're suddenly wetting yourself!",
 		"With a faint hiss, warmth floods into your $UNDERWEAR_NAME$!",
-		"You uselessly press your hands to your crotch to try stop the sudden flood of pee coming out.",
+		"You press your hands to your crotch, feeling the warmth as the sudden flood of pee comes rushing out.",
 		"You're wetting your $UNDERWEAR_NAME$ like a little <boy/girl>!",
-		"You can't hold it any longer and your pee gushes out, flooding your $UNDERWEAR_NAME$.",
-		"You can't help yourself and pee spurts into your $UNDERWEAR_NAME$",
-		"Oh no! You're wetting yourself!",
-		"You're wetting your $UNDERWEAR_NAME$! Oh no!",
-		"You can't stop yourself from peeing in your $UNDERWEAR_NAME$!",
-		"Your $UNDERWEAR_NAME$ <sags#sag> as you wet yourself. How humiliating!"
+		"You give up trying to hold it any longer and your pee gushes out, flooding your $UNDERWEAR_NAME$.",
+		"You can't help but relax and let your pee spurt into your $UNDERWEAR_NAME$",
+		"Oopsies! You're wetting yourself!",
+		"You're wetting your $UNDERWEAR_NAME$! Oh well.",
+		"You notice a growing warmth befor glancing down and relaizing you're peeing in your $UNDERWEAR_NAME$!",
+		"Your $UNDERWEAR_NAME$ <sags#sag> as you wet yourself. Your cheeks flush as you realize you're just a little <boy/girl>."
 	],
 	"Mess_Accident": [
-		"Trying not to cry, you helplessly mess your $UNDERWEAR_NAME$.",
-		"Turning bright red, you realize you're suddenly filling the back of your $UNDERWEAR_NAME$!",
-		"Your cheeks burn as the distinctive smell of poop begins to waft from your $UNDERWEAR_NAME$.",
-		"You cover your face in shame as you involuntarily fill your $UNDERWEAR_NAME$ with warm poop.",
+		"Your knees bend and your body bushes on its own as you find yourself pushing a warm load into your $UNDERWEAR_NAME$.",
+		"You realize you're suddenly filling the back of your $UNDERWEAR_NAME$! You heft your seat with a slight blush as your warm, soft muck squishes against you.",
+		"You sigh with relief and grin bashfully as the distinctive smell of poop begins to waft from your $UNDERWEAR_NAME$.",
+		"You bashfully cover your face as you fill your $UNDERWEAR_NAME$ with warm poop. After you're done, you realize your thumb found it's way into your mouth",
 		"With a faint crackling sound, your poop squeezes out into your $UNDERWEAR_NAME$.",
 		"You start squirming and push a heavy load of poop into your $UNDERWEAR_NAME$.",
-		"You whimper helplessly. You're pooping yourself!",
-		"You can't hold your poop any more and release it into your $UNDERWEAR_NAME$.",
-		"You finally give up, and a heavy load of warm poop pushes into your $UNDERWEAR_NAME$.",
-		"You freeze up and look around nervously as your poop squishes out into your $UNDERWEAR_NAME$.",
-		"You're pooping in your pants! How humiliating!",
-		"You feel a warm mass spreading into your $UNDERWEAR_NAME$ and start to cry like a little <boy/girl>.",
-		"You push on the back of your $UNDERWEAR_NAME$ to stop the poop coming out, but you only squish it around more!",
-		"Oh no! Your $UNDERWEAR_NAME$ <is#are> all messy now!",
-		"You can't stop it! You're messing yourself!",
+		"You're almost startled as you notice it. You're pooping yourself!",
+		"You don't want to hold your poop any more and release it into your $UNDERWEAR_NAME$.",
+		"You finally give in, and a heavy load of warm poop pushes into your $UNDERWEAR_NAME$.",
+		"You freeze up and look around sheepishly as your poop squishes out into your $UNDERWEAR_NAME$.",
+		"You're pooping in your pants!",
+		"You feel a warm mass spreading into your $UNDERWEAR_NAME$ and feel like a little <boy/girl>.",
+		"You push on the back of your $UNDERWEAR_NAME$ as <it#they> <bulges#bulge>, giggling as it squishes around",
+		"Oopsies! Your $UNDERWEAR_NAME$ <is#are> all messy now!",
+		"You don't try and stop it any longer! You're messing yourself!",
 		"You mess your $UNDERWEAR_NAME$ like a little baby <boy/girl>!",
-		"Your $UNDERWEAR_NAME$ <bulges#bulge> as you helplessly mess yourself.",
-		"You can't help yourself and mess your $UNDERWEAR_NAME$!"
+		"Your $UNDERWEAR_NAME$ <bulges#bulge> as you openly mess yourself.",
+		"You give up trying to hold it and sigh in relief as you mess your $UNDERWEAR_NAME$!"
 	],
 	"Toilet_Night": [
 		"You had to <pee&poop> last night, and made it to the toilet$HOW_MANY_TIMES",
@@ -200,7 +200,7 @@
 		"You find that you leaked last night--your bed is all wet!",
 		"Your bed is cold and wet. You must have wet the bed last night!",
 		"You wet your bed like a little <boy/girl> last night!",
-		"You realize in shame that you're lying in a puddle of cold pee.",
+		"You wake up uncomfortable, lying in a puddle of cold pee.",
 		"Your covers are all wet. You need a diaper like a little <boy/girl>!",
 		"Your pajamas are uncomfortable and wet. You realize you wet the bed last night!"
 	],
@@ -209,7 +209,7 @@
 		"Somebody needs a diaper! You <wet and >messed your bed last night!",
 		"Your cheeks burn when you discover that your bed is all <wet and >poopy!",
 		"You are humiliated to realize that you pooped< and peed> in your bed while you were sleeping!",
-		"You <pee and >poop overflowed into your bed last night!",
+		"Your <pee and >poop overflowed into your bed last night!",
 		"You realize you must have <wet and >messed your bed last night! Oh no!",
 		"You smell something stinky and realize you <wet and >messed the bed last night!"
 	],
@@ -249,25 +249,35 @@
 	"Debuff_Messy_Pants": [ "Your pants are messy!", "Your pants are poopy!", "You messed your pants!" ],
 	"Villager_Reactions": {
 		"adult": {
-			"soiled_verynice": [ "Aww, do you need me to change you out of your <wet&messy> $UNDERWEAR_NAME$?", "I think little $FARMERNAME$ needs <his/her> diaper changed!" ],
+			"soiled_verynice": [ "Aww, do you need me to change you out of your <wet&messy> $UNDERWEAR_NAME$?", "I think little $FARMERNAME$ needs <his/her> diaper changed!", "I know a little farmer who needs <his/her> diaper changed!$1"],
 			"soiled_nice": [ "You poor thing! Did you just <wet&mess> yourself?", "Does someone need a diaper change?" ],
 			"soiled_mean": [ "You <&really >might want to go change your pants." ],
-			"ground": [ "$FARMERNAME$! Living in the country doesn't make us barbarians!", "That's not okay! Use a toilet!" ],
-			"ground_attempt": [ "$FARMERNAME$! What are you doing!" ]
+			"ground": [ "$FARMERNAME$! Living in the country doesn't make us barbarians!$3", "That's not okay! Use a toilet!$3" ],
+			"ground_attempt": [ "$FARMERNAME$! What are you doing!$3" ]
 		},
 		"teen": {
-			"soiled_verynice": [ "Awww, you're so cute when you're embarrassed!", "Where's your mommy $FARMERNAME$? I think you need a change." ],
+			"soiled_verynice": [ "Awww, you're so cute when you're embarrassed!$1", "Where's your mommy $FARMERNAME$? I think you need a change." ],
 			"soiled_nice": [ "Did you just <wet&mess> yourself $FARMERNAME$?", "Just letting you know $FARMERNAME$, you should probably change your diaper soon." ],
-			"soiled_mean": [ "Did you just <pee&poop> in your pants? Gross!", "Wow, you're such a baby $FARMERNAME$!" ],
-			"ground": [ "Eww. Is that normal in the city?", "What... Ugh!", "Did you just <pee&poop> on the ground? Gross!" ],
-			"ground_attempt": [ "What... Put your pants back on!" ]
+			"soiled_mean": [ "Did you just <pee&poop> in your pants? Gross!$5", "Wow, you're such a baby $FARMERNAME$!" ],
+			"ground": [ "Eww. Is that normal in the city?$5", "What... Ugh!$5", "Did you just <pee&poop> on the ground? Gross!$5" ],
+			"ground_attempt": [ "What... Put your pants back on!$5" ]
 		},
 		"kid": {
-			"soiled_verynice": [ "Go ask your mommy to check your diaper.", "Don't cry, it's okay for little <boy/girl>s to have accidents sometimes." ],
-			"soiled_nice": [ "I can see you waddling!", "It smells like you need a diaper change!" ],
-			"soiled_mean": [ "Hah! I just watched you <pee&poop> yourself!", "You <peed&pooped> yourself!", "$FARMERNAME$ just <peed&pooped> <himself/herself>!" ],
-			"ground": [ "Ewww!", "Ewww! Don't <pee&poop> there!", "Hey everyone! $FARMERNAME$ just <peed&pooped> on the ground!" ],
-			"ground_attempt": [ "Eww! Why are you trying to <pee&poop> on on the ground?" ]
+			"soiled_verynice": [ 
+				"#$p 102#%Did you hear something?|Go ask your mommy to check your diaper.", 
+				"#$p 102#%Did you hear something?|Don't cry, it's okay for little <boy/girl>s to have accidents sometimes." ],
+			"soiled_nice": [ 
+				"#$p 102#%Did you hear something?|I can see you waddling!", 
+				"#$p 102#%Did you hear something?|It smells like you need a diaper change!" ],
+			"soiled_mean": [ 
+				"#$p 102#%Did you hear something?|Hah! I just watched you <pee&poop> yourself!$1", 
+				"#$p 102#%Did you hear something?|You <peed&pooped> yourself!", 
+				"#$p 102#%Did you hear something?|$FARMERNAME$ just <peed&pooped> <himself/herself>!$1" ],
+			"ground": [ 
+				"#$p 102#%Did you hear something?|Ewww!$3", "Ewww! Don't <pee&poop> there!$3", 
+				"#$p 102#%Did you hear something?|Hey everyone! $FARMERNAME$ just <peed&pooped> on the ground!$1" ],
+			"ground_attempt": [ 
+				"#$p 102#%Did you hear something?|Eww! Why are you trying to <pee&poop> on on the ground?$3" ]
 		},
 		"animal": {
 			"soiled_nice": [ "...", "???" ],
@@ -276,12 +286,12 @@
 		},
 		"abigail": {
 			"soiled_verynice": [
-				"$hWant a change? I could change you, if you want!",
-				"$lAre you ever going to change me someday?",
-				"$lSometimes I just put on a diaper and sit around playing games all day. Maybe we could do that together sometime.",
-				"$sI think I'm pretty wet. Would you mind helping me change?",
-				"$hLet me help with that! Lay down for me.",
-				"$lEwww, I think.... I think I pooped myself. Could you... maybe change me?"
+				"Want a change? #$b#I could change you, if you want!$h",
+				"Sometimes I just put on a diaper and sit around playing games all day. #$b#Maybe we could do that together sometime.$h",
+				"I think I'm pretty wet. #$b#Would you mind helping me change?",
+				"Let me help with that! Lay down for me.$h",
+				"Ewww, I think.... I think I pooped myself.$s #$b#...$s #$b#Could you... maybe change me?"
+			
 			],
 			"soiled_nice": [
 				"$lWas that me? ...Oh! Nothing! Haha!",
@@ -315,7 +325,72 @@
 				"$uLike, eww. Why is everyone in this town so gross?!",
 				"$uI was gonna tell you to change your clothes because of how unstylish they are, but it looks like you need your diaper changed more, you big baby!"
 			]
-		}
+		},
+		"jodi": {
+			"soiled_verynice": [
+				"%Jodi leans down to put a comforting hand on your back.#$b#You can tell me if you had a little accident $FARMERNAME$. It's nothing to be ashamed of.",
+				"You don't need to rush potty training if you're not ready yet.",
+				"It can be hard for little <boys/girls> to remember to go potty sometimes. It's okay.",
+				"Oh goodness!$1",
+				"Awww, you're so cute when you're embarrassed!$1",
+			],
+			"soiled_nice": [
+				"$FARMERNAME$, I  think you might need to go change.",
+				"You poor thing! Did you just <wet&mess> yourself?",
+			],
+			"soiled_mean": [
+				"You might need to tap into those supplies I left you$4",
+			]
+		},
+		"sam": {
+			"soiled_verynice": [
+				"#$p 102#Oh man, that was pretty hard to miss!$1|Man, you're just like Vincent.$1",
+				"Are you okay buddy?#$b#$y 'Do you want some help with that?_Yes please._Alright, go get a change and lie down for me. I'll clean you right up$3_Not yet!_Looks like the little <boy/girl> wants to stay <wet&messy> a bit longer!$1'",
+				"It's okay $FARMERNAME$. Accidents are nothing to be ashamed of.",
+				"Awwww, look at you go! That must have felt good.$4",
+				"Oh man, that was pretty hard to miss!$1",
+				"Good one!$1",
+				"Man, you're such a little baby sometimes.#$b#%Sam giggles a bit as he pats your squishy bottom.",
+				"Awww, did the little farmer have a little accident?",
+				"I bet I could get Mommy to go change you.$3#$b#I'm kidding I'm kidding!$1",
+				"Man, it looks like you really need diapers, don't you.",
+				"Oh wow, you really <wet&messed> yourself!#$b#$y 'Can I feel it?_Yes._%Sam blushes as he presses his hand into your squishy diaper._No thank you._Okay, I won't.'",
+			],
+			"soiled_nice": [
+				"You might wanna change. Just incase someone else says something.$7",
+				"A-are you okay?$8",
+				"%Sam just blushes a as you <wet&mess> yourself. You take note of how closely he watches the whole scene.",
+				"Oh man, I'm sorry. That can't feel good.",
+				
+			],
+			"soiled_mean": [
+				"I'm just..nevermind.$5",
+				"This is pretty awkward.$2",
+				"...Oh$2",
+				"#$p 102#You might want to take care of that...|Great, more potty issues to be witness to. Thanks.$5",
+			]
+		},
+		"vincent": {
+			"soiled_verynice": [
+				"#$p 102#%Vincent doesn't seem to notice what happened.|Mommy told me big kids are supposed to use the potty. #$b#I don't wanna be a big kid either!$1",
+				"#$p 102#%Vincent doesn't seem to notice what happened.|%Vincent watches you <wet&mess> yourself and giggles.#$b#Good one!$1",
+				"#$p 102#%Vincent doesn't seem to notice what happened.|%You notice Vincent watching as you <wet&mess> yourself.#$b#All better?",
+				"#$p 102#%Vincent doesn't seem to notice what happened.|%Vincent watches the whole scene curiously and giggles when you look over. #$b# You <peed&pooped>!$1",				
+				"#$p 102#%Vincent doesn't seem to notice what happened.|If you want I could ask my mommy to change you.#$b#No?#$b#That's okay, I like being <wet&messy> too!$1",
+				"#$p 102#%Vincent doesn't seem to notice what happened.|$FARMERNAME$'s <wet&messy> and I'm still dry!$1#$b#...#$b#Wait...$2",
+			
+			],
+			"soiled_nice": [
+				"#$p 102#%Vincent doesn't seem to notice what happened.|Don't cry, Mommy says it's okay to have accidents sometimes.",
+				"#$p 102#%Vincent doesn't seem to notice what happened.|Don't worry $FARMERNAME$, I still do that too!",
+				"#$p 102#%Vincent doesn't seem to notice what happened.|Feel all better?",
+			],
+			"soiled_mean": [
+				"#$p 102#%Vincent doesn't seem to notice what happened.|%Vincent saw what happened and snickers at you.",
+				"#$p 102#%Vincent doesn't seem to notice what happened.|Was that an accident?",
+				"#$p 102#%Vincent doesn't seem to notice what happened.|Ha! Gross!$1",
+			]
+		},
 	},
 
 	"Change": [

--- a/Regression/manifest.json
+++ b/Regression/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Regression",
   "Author": "Various",
-  "Version": "1.2.2",
+  "Version": "1.2.3",
   "Description": "Diaper Wetting Mod",
   "UniqueID": "Zippity21.Regression",
   "EntryDll": "Regression.dll",


### PR DESCRIPTION
Regression Dialogue Folder was added.

It has a manifest that uses Content Patcher.

The content.JSON tells Content Patcher to look in the Dialogue folder for changes.

When talking to Vincent or Jas for the first time, the player will get a question about whether or not they'd want ABDL lines for them. If they choose no, all ABDL changes for them will be replaced with normal dialogue. This includes reactions to the player using their pants.

Jodi has full dialogue for every day of the year.

Sam has full ABDL dialogue and full marriage ABDL dialogue.

Vincent has full dialogue for every day of the year.

Sebastion has one ABDL question for when I was learning how to do that.

Jas has the introduction question.

en.JSON was edited to have less humilation, full Jodi and Sam reactions, and Vincent which are avoided if the intro question was answered no.