### PR TITLE
Softlock Fix + Switch to Mainline SMAPI

### DIFF
--- a/Regression/PrimevalTitmouse/Animations.cs
+++ b/Regression/PrimevalTitmouse/Animations.cs
@@ -16,7 +16,8 @@ namespace PrimevalTitmouse
 
     internal static class Animations
     {
-        private static readonly List<string> NPC_LIST = new List<string> { "Linus", "Krobus", "Dwarf" };
+        //<FIXME> Adding Leo here as a quick fix to a softlock issue due to not having ABDL dialogue written
+        private static readonly List<string> NPC_LIST = new List<string> { "Linus", "Krobus", "Dwarf", "Leo" };
         public static readonly int poopAnimationTime = 2000; //ms
         public static readonly int peeAnimationTime = 2000; //ms
         //Magic Constants

--- a/Regression/PrimevalTitmouse/Body.cs
+++ b/Regression/PrimevalTitmouse/Body.cs
@@ -33,9 +33,9 @@ namespace PrimevalTitmouse
         private static readonly string[][] WETTING_MESSAGES = { Regression.t.Bladder_Red, Regression.t.Bladder_Orange, Regression.t.Bladder_Yellow };
         private static readonly float[] MESSING_THRESHOLDS = { 0.15f, 0.4f, 0.6f };
         private static readonly string[][] MESSING_MESSAGES = { Regression.t.Bowels_Red, Regression.t.Bowels_Orange, Regression.t.Bowels_Yellow };
-        private static readonly float[] BLADDER_CONTINENCE_THRESHOLDS = { 0.6f, 0.2f, 0.5f, 0.8f };
+        private static readonly float[] BLADDER_CONTINENCE_THRESHOLDS = { 0.2f, 0.5f, 0.6f, 0.8f };
         private static readonly string[][] BLADDER_CONTINENCE_MESSAGES = { Regression.t.Bladder_Continence_Min, Regression.t.Bladder_Continence_Red, Regression.t.Bladder_Continence_Orange, Regression.t.Bladder_Continence_Yellow };
-        private static readonly float[] BOWEL_CONTINENCE_THRESHOLDS = { 0.6f, 0.2f, 0.5f, 0.8f };
+        private static readonly float[] BOWEL_CONTINENCE_THRESHOLDS = { 0.2f, 0.5f, 0.6f, 0.8f };
         private static readonly string[][] BOWEL_CONTINENCE_MESSAGES = { Regression.t.Bowel_Continence_Min, Regression.t.Bowel_Continence_Red, Regression.t.Bowel_Continence_Orange, Regression.t.Bowel_Continence_Yellow };
         private static readonly float[] HUNGER_THRESHOLDS = { 0.0f, 0.25f };
         private static readonly string[][] HUNGER_MESSAGES = { Regression.t.Food_None, Regression.t.Food_Low };
@@ -746,7 +746,7 @@ namespace PrimevalTitmouse
                 this.AddWater(item.waterContent);
             } else
             {
-                this.AddFood(200);
+                this.AddFood(400);
                 this.AddWater(10);
             }
         }

--- a/Regression/Regression.csproj
+++ b/Regression/Regression.csproj
@@ -35,10 +35,16 @@
     <None Update="Regression Dialogue\Content.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Regression Dialogue\Dialogue\NPCs\Gus.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Regression Dialogue\Dialogue\NPCs\Jas.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Regression Dialogue\Dialogue\NPCs\Jodi.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Regression Dialogue\Dialogue\NPCs\Penny.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Regression Dialogue\Dialogue\NPCs\Sam.json">
@@ -56,7 +62,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell rm -Recurse -Force  '$(TargetDir)\Regression Mod'&#xD;&#xA;powershell mkdir '$(TargetDir)\Regression Mod'&#xD;&#xA;powershell mkdir '$(TargetDir)\Regression Mod\Regression'&#xD;&#xA;powershell cp -Recurse -Force '$(TargetDir)\*' '$(TargetDir)\Regression Mod\Regression' -Exclude 'Regression Mod','Regression Dialogue'&#xD;&#xA;powershell cp -Recurse -Force '$(TargetDir)\Regression Dialogue' '$(TargetDir)\Regression Mod'&#xD;&#xA;powershell Compress-Archive '$(TargetDir)\Regression Mod' '$(TargetDir)\Regression Mod.zip' -Force" />
+    <Exec Command="powershell rm -Recurse -Force  '$(TargetDir)\Regression Mod'&#xD;&#xA;powershell New-Item -Path '$(TargetDir)' -Name &quot;Regression Mod.zip&quot; -ItemType &quot;file&quot; -Value &quot;DUMMY&quot; -Force&#xD;&#xA;powershell rm -Force   '$(TargetDir)\Regression Mod.zip'&#xD;&#xA;powershell mkdir '$(TargetDir)\Regression Mod'&#xD;&#xA;powershell mkdir '$(TargetDir)\Regression Mod\Regression'&#xD;&#xA;powershell cp -Recurse -Force '$(TargetDir)\*' '$(TargetDir)\Regression Mod\Regression' -Exclude 'Regression Mod','Regression Dialogue'&#xD;&#xA;powershell cp -Recurse -Force '$(TargetDir)\Regression Dialogue' '$(TargetDir)\Regression Mod'&#xD;&#xA;powershell Compress-Archive '$(TargetDir)\Regression Mod' '$(TargetDir)\Regression Mod.zip' -Force" />
   </Target>
 
 </Project>

--- a/Regression/manifest.json
+++ b/Regression/manifest.json
@@ -1,11 +1,11 @@
 ﻿{
   "Name": "Regression",
   "Author": "Various",
-  "Version": "1.2.4",
+  "Version": "1.2.5",
   "Description": "Diaper Wetting Mod",
   "UniqueID": "Zippity21.Regression",
   "EntryDll": "Regression.dll",
-  "MinimumApiVersion": "3.13.0-beta.20211018",
+  "MinimumApiVersion": "3.13.2",
   "UpdateKeys": [ "GitHub:zippity21/Stardew_Valley_Regression_Mod" ],
   "Dependencies": [
     {


### PR DESCRIPTION
Temporary fix for softlocking in Leo's hunt when having an accident in front of him. Exempt from reactions until unique dialogue is written. (Fixes #51 )

Also fixes a minor issue with continence warning threshold values.

Update manifest to point to non-beta SMAPI release.