### PR TITLE
Fix for stardew 1.6 update

### DIFF
--- a/Regression.sln
+++ b/Regression.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31729.503
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Regression", "Regression\Regression.csproj", "{65F7FD12-03C5-440C-9F47-2A86A25362DA}"
 EndProject

--- a/Regression/PrimevalTitmouse/Animations.cs
+++ b/Regression/PrimevalTitmouse/Animations.cs
@@ -30,8 +30,8 @@ namespace PrimevalTitmouse
     {
         //<FIXME> Adding Leo here as a quick fix to a softlock issue due to not having ABDL dialogue written
         private static readonly List<string> NPC_LIST = new List<string> { "Linus", "Krobus", "Dwarf", "Leo" };
-        public static readonly int poopAnimationTime = 1200; //ms
-        public static readonly int peeAnimationTime = 600; //ms
+        public static readonly int poopAnimationTime = 2000; //ms
+        public static readonly int peeAnimationTime = 2000; //ms
         //Magic Constants
         public const string SPRITES = "Assets/sprites.png";
         public const int PAUSE_TIME = 20000;

--- a/Regression/PrimevalTitmouse/Animations.cs
+++ b/Regression/PrimevalTitmouse/Animations.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Characters;
 using StardewValley.Menus;
@@ -10,6 +11,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace PrimevalTitmouse
 {
@@ -28,8 +30,8 @@ namespace PrimevalTitmouse
     {
         //<FIXME> Adding Leo here as a quick fix to a softlock issue due to not having ABDL dialogue written
         private static readonly List<string> NPC_LIST = new List<string> { "Linus", "Krobus", "Dwarf", "Leo" };
-        public static readonly int poopAnimationTime = 2000; //ms
-        public static readonly int peeAnimationTime = 2000; //ms
+        public static readonly int poopAnimationTime = 1200; //ms
+        public static readonly int peeAnimationTime = 600; //ms
         //Magic Constants
         public const string SPRITES = "Assets/sprites.png";
         public const int PAUSE_TIME = 20000;
@@ -58,7 +60,7 @@ namespace PrimevalTitmouse
         }
         public static Texture2D GetSprites()
         {
-            sprites ??= Regression.help.Content.Load<Texture2D>(SPRITES, StardewModdingAPI.ContentSource.ModFolder);
+            sprites ??= Regression.help.ModContent.Load<Texture2D>(SPRITES);
             return sprites;
         }
 
@@ -110,7 +112,7 @@ namespace PrimevalTitmouse
         public static void AnimateMessingStart(Body b, bool voluntary, bool inUnderwear)
         {
 
-            if (b.IsFishing()) return;
+            if (b.IsFishing() || !Animations.GetWho().canMove) return;
 
             if (b.underwear.removable || inUnderwear)
                 Game1.playSound("slosh");
@@ -139,7 +141,7 @@ namespace PrimevalTitmouse
             //Animations.GetWho().forceCanMove();
             //Animations.GetWho().completelyStopAnimatingOrDoingAction();
             Animations.GetWho().jitterStrength = 1.0f;
-            Game1.currentLocation.temporarySprites.Add(new TemporaryAnimatedSprite("TileSheets\\animations", new Microsoft.Xna.Framework.Rectangle(192, 1152, Game1.tileSize, Game1.tileSize), 50f, 4, 0, Animations.GetWho().position - new Vector2(((Character)Animations.GetWho()).facingDirection == 1 ? 0.0f : (float)-Game1.tileSize, (float)(Game1.tileSize * 2)), false, ((Character)Animations.GetWho()).facingDirection == 1, (float)((Character)Animations.GetWho()).getStandingY() / 10000f, 0.01f, Microsoft.Xna.Framework.Color.White, 1f, 0.0f, 0.0f, 0.0f, false));
+            Game1.currentLocation.temporarySprites.Add(new TemporaryAnimatedSprite("TileSheets\\animations", new Microsoft.Xna.Framework.Rectangle(192, 1152, Game1.tileSize, Game1.tileSize), 50f, 4, 0, Animations.GetWho().position.Value - new Vector2(((Character)Animations.GetWho()).facingDirection.Value == 1 ? 0.0f : (float)-Game1.tileSize, (float)(Game1.tileSize * 2)), false, ((Character)Animations.GetWho()).facingDirection.Value == 1, (float)((Character)Animations.GetWho()).StandingPixel.Y / 10000f, 0.01f, Microsoft.Xna.Framework.Color.White, 1f, 0.0f, 0.0f, 0.0f, false));
 
             Animations.GetWho().freezePause = poopAnimationTime;
             Animations.GetWho().canMove = false;
@@ -150,12 +152,12 @@ namespace PrimevalTitmouse
 
             if (b.IsFishing()) return;
             Game1.playSound("coin");
-            Game1.currentLocation.temporarySprites.Add(new TemporaryAnimatedSprite("TileSheets\\animations", new Microsoft.Xna.Framework.Rectangle(192, 1152, Game1.tileSize, Game1.tileSize), 50f, 4, 0, Animations.GetWho().position - new Vector2(Animations.GetWho().facingDirection == 1 ? 0.0f : -Game1.tileSize, Game1.tileSize * 2), false, Animations.GetWho().facingDirection == 1, Animations.GetWho().getStandingY() / 10000f, 0.01f, Microsoft.Xna.Framework.Color.White, 1f, 0.0f, 0.0f, 0.0f, false));
+            Game1.currentLocation.temporarySprites.Add(new TemporaryAnimatedSprite("TileSheets\\animations", new Microsoft.Xna.Framework.Rectangle(192, 1152, Game1.tileSize, Game1.tileSize), 50f, 4, 0, Animations.GetWho().position.Value - new Vector2(Animations.GetWho().facingDirection.Value == 1 ? 0.0f : -Game1.tileSize, Game1.tileSize * 2), false, Animations.GetWho().facingDirection.Value == 1, Animations.GetWho().StandingPixel.Y / 10000f, 0.01f, Microsoft.Xna.Framework.Color.White, 1f, 0.0f, 0.0f, 0.0f, false));
         }
 
         public static void AnimateWettingStart(Body b, bool voluntary, bool inUnderwear)
         {
-            if (b.IsFishing()) return;
+            if (b.IsFishing() || !Animations.GetWho().canMove) return;
 
             if(b.underwear.removable || inUnderwear)
               Game1.playSound("wateringCan");
@@ -176,9 +178,9 @@ namespace PrimevalTitmouse
                 else
                     Animations.Say(Animations.GetData().Pee_Voluntary, b);
 
-                ((List<TemporaryAnimatedSprite>)((GameLocation)Animations.GetWho().currentLocation).temporarySprites).Add(new TemporaryAnimatedSprite(13, (Vector2)((Character)Game1.player).position, Microsoft.Xna.Framework.Color.White, 10, ((Random)Game1.random).NextDouble() < 0.5, 70f, 0, (int)Game1.tileSize, 0.05f, -1, 0));
+                ((GameLocation)Animations.GetWho().currentLocation).temporarySprites.Add(new TemporaryAnimatedSprite(13, (Vector2)((Character)Game1.player).position.Value, Microsoft.Xna.Framework.Color.White, 10, ((Random)Game1.random).NextDouble() < 0.5, 70f, 0, (int)Game1.tileSize, 0.05f, -1, 0));
                 HoeDirt terrainFeature;
-                if (Animations.GetWho().currentLocation.terrainFeatures.ContainsKey(((Character)Animations.GetWho()).getTileLocation()) && (terrainFeature = Animations.GetWho().currentLocation.terrainFeatures[((Character)Animations.GetWho()).getTileLocation()] as HoeDirt) != null)
+                if (Animations.GetWho().currentLocation.terrainFeatures.ContainsKey(((Character)Animations.GetWho()).Tile) && (terrainFeature = Animations.GetWho().currentLocation.terrainFeatures[((Character)Animations.GetWho()).Tile] as HoeDirt) != null)
                     terrainFeature.state.Value = 1;
             }
             else if (voluntary)
@@ -199,9 +201,9 @@ namespace PrimevalTitmouse
             if (b.IsFishing()) return;
             if ((double)b.pants.wetness > (double)b.pants.absorbency)
             {
-                ((List<TemporaryAnimatedSprite>)((GameLocation)Animations.GetWho().currentLocation).temporarySprites).Add(new TemporaryAnimatedSprite(13, (Vector2)((Character)Game1.player).position, Microsoft.Xna.Framework.Color.White, 10, ((Random)Game1.random).NextDouble() < 0.5, 70f, 0, (int)Game1.tileSize, 0.05f, -1, 0));
+                ((GameLocation)Animations.GetWho().currentLocation).temporarySprites.Add(new TemporaryAnimatedSprite(13, (Vector2)((Character)Game1.player).position.Value, Microsoft.Xna.Framework.Color.White, 10, ((Random)Game1.random).NextDouble() < 0.5, 70f, 0, (int)Game1.tileSize, 0.05f, -1, 0));
                 HoeDirt terrainFeature;
-                if (Animations.GetWho().currentLocation.terrainFeatures.ContainsKey(((Character)Animations.GetWho()).getTileLocation()) && (terrainFeature = Animations.GetWho().currentLocation.terrainFeatures[((Character)Animations.GetWho()).getTileLocation()] as HoeDirt) != null)
+                if (Animations.GetWho().currentLocation.terrainFeatures.ContainsKey(((Character)Animations.GetWho()).Tile) && (terrainFeature = Animations.GetWho().currentLocation.terrainFeatures[((Character)Animations.GetWho()).Tile] as HoeDirt) != null)
                     terrainFeature.state.Value = 1;
             }
         }
@@ -299,15 +301,6 @@ namespace PrimevalTitmouse
             }
         }
 
-
-        public static Texture2D Bitmap2Texture(Bitmap bmp)
-        {
-            MemoryStream memoryStream = new MemoryStream();
-            bmp.Save((Stream)memoryStream, ImageFormat.Png);
-            memoryStream.Seek(0L, SeekOrigin.Begin);
-            return Texture2D.FromStream(((GraphicsDeviceManager)Game1.graphics).GraphicsDevice, (Stream)memoryStream);
-        }
-
         public static void CheckPants(Body b)
         {
             StardewValley.Objects.Clothing pants = (StardewValley.Objects.Clothing)Animations.GetWho().pantsItem.Value;
@@ -337,7 +330,7 @@ namespace PrimevalTitmouse
                     string source = Strings.DescribeUnderwear(c, (string)null);
                     string str = source.First<char>().ToString().ToUpper() + source.Substring(1);
                     int num = Game1.tileSize * 6 + Game1.tileSize / 6;
-                    IClickableMenu.drawHoverText((SpriteBatch)Game1.spriteBatch, Game1.parseText(str, (SpriteFont)Game1.tinyFont, num), (SpriteFont)Game1.smallFont, 0, 0, -1, (string)null, -1, (string[])null, (Item)null, 0, -1, -1, -1, -1, 1f, (CraftingRecipe)null);
+                    IClickableMenu.drawHoverText((SpriteBatch)Game1.spriteBatch, Game1.parseText(str, (SpriteFont)Game1.tinyFont, num), (SpriteFont)Game1.smallFont, 0, 0, -1, (string)null, -1, (string[])null, (Item)null, 0, null, -1, -1, -1, 1f, (CraftingRecipe)null);
                 }
         }
 
@@ -349,9 +342,9 @@ namespace PrimevalTitmouse
 
         public static void HandlePasserby()
         {
-            if (Utility.isThereAFarmerOrCharacterWithinDistance(Animations.GetWho().getTileLocation(), 3, (GameLocation)Game1.currentLocation) is not NPC npc || NPC_LIST.Contains(npc.Name))
+            if (Utility.isThereAFarmerOrCharacterWithinDistance(Animations.GetWho().Tile, 3, (GameLocation)Game1.currentLocation) is not NPC npc || NPC_LIST.Contains(npc.Name))
                 return;
-            npc.CurrentDialogue.Push(new Dialogue("Oh wow, your diaper is all wet!", npc));
+            npc.CurrentDialogue.Push(new Dialogue(npc, null, "Oh wow, your diaper is all wet!"));
         }
 
         public static bool HandleVillager(Body b, bool mess, bool inUnderwear, bool overflow, bool attempt = false, int baseFriendshipLoss = 20, int radius = 3)
@@ -385,7 +378,7 @@ namespace PrimevalTitmouse
 
             //Get NPC in radius
             //<TODO> This needs to be reworked to get a list of NPCs
-            if (Utility.isThereAFarmerOrCharacterWithinDistance(((Character)Animations.GetWho()).getTileLocation(), radius, (GameLocation)Game1.currentLocation) is not NPC npc || NPC_LIST.Contains(npc.Name))
+            if (Utility.isThereAFarmerOrCharacterWithinDistance(((Character)Animations.GetWho()).Tile, radius, (GameLocation)Game1.currentLocation) is not NPC npc || NPC_LIST.Contains(npc.Name))
                 return false;
 
             //Reduce the loss if the person likes you (more forgiving)
@@ -473,14 +466,14 @@ namespace PrimevalTitmouse
 
             //Construct and say Statement
             string npcStatement = npcName + Strings.InsertVariables(Strings.ReplaceAndOr(Strings.RandString(stringList3.ToArray()), !mess, mess, "&"), b, (Container)null);
-            npc.setNewDialogue(npcStatement, true, true);
+            npc.setNewDialogue(new Dialogue(npc, null, npcStatement), true, true);
             Game1.drawDialogue(npc);
             return someoneNoticed;
         }
 
         public static Texture2D LoadTexture(string file)
         {
-            return Animations.Bitmap2Texture(new Bitmap(Image.FromFile(Path.Combine(Regression.help.DirectoryPath, "Assets", file))));
+            return Regression.help.ModContent.Load<Texture2D>(Path.Combine("Assets", file));
         }
 
         public static void Say(string msg, Body b = null)

--- a/Regression/PrimevalTitmouse/Body.cs
+++ b/Regression/PrimevalTitmouse/Body.cs
@@ -160,8 +160,6 @@ namespace PrimevalTitmouse
             //Did we go over? Then have an accident.
             if (bowelFullness >= bowelCapacity)
             {
-                Regression.monitor.Log(string.Format("Exceeded bowel capacity {0} {1}", bowelFullness, bowelCapacity));
-
                 Mess(voluntary: false, inUnderwear: true);
             }
             else
@@ -445,24 +443,19 @@ namespace PrimevalTitmouse
                 StartMessing(voluntary, true); //Always in underwear in bed
                                                //Any overage in the container, add to the pants. Ignore overage over that.
 
-                Regression.monitor.Log("Mess - inUnderwear");
                 if (bowelFullness >= GetBowelAttemptThreshold())
                 {
                     _ = this.pants.AddPoop(this.underwear.AddPoop(bowelFullness));
-                    Regression.monitor.Log("Reset to 0");
                     this.bowelFullness = 0.0f;
                 }
             }
             else
             {
                 StartMessing(voluntary, false);
-                Regression.monitor.Log("Mess - not inUnderwear");
                 if (underwear.removable)
                 {
-                    Regression.monitor.Log("Removable");
                     if (bowelFullness >= GetBowelAttemptThreshold())
                     {
-                        Regression.monitor.Log("Reset to 0");
                         this.bowelFullness = 0.0f;
                     }
                 }

--- a/Regression/PrimevalTitmouse/Body.cs
+++ b/Regression/PrimevalTitmouse/Body.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.Xna.Framework;
+using StardewModdingAPI;
 using StardewValley;
+using StardewValley.Buffs;
 using StardewValley.Locations;
-using StardewValley.Menus;
 using StardewValley.Tools;
 using System;
-using System.Collections.Generic;
 
 namespace PrimevalTitmouse
 {
@@ -41,8 +41,8 @@ namespace PrimevalTitmouse
         private static readonly string[][] HUNGER_MESSAGES = { Regression.t.Food_None, Regression.t.Food_Low };
         private static readonly float[] THIRST_THRESHOLDS = { 0.0f, 0.25f };
         private static readonly string[][] THIRST_MESSAGES = { Regression.t.Water_None, Regression.t.Water_Low };
-        private static readonly int MESSY_DEBUFF = 222;
-        private static readonly int WET_DEBUFF = 111;
+        private static readonly string MESSY_DEBUFF = "Regression.Messy";
+        private static readonly string WET_DEBUFF = "Regression.Wet";
         private static readonly int wakeUpPenalty = 4;
 
         //Things that describe an individual
@@ -160,8 +160,9 @@ namespace PrimevalTitmouse
             //Did we go over? Then have an accident.
             if (bowelFullness >= bowelCapacity)
             {
+                Regression.monitor.Log(string.Format("Exceeded bowel capacity {0} {1}", bowelFullness, bowelCapacity));
+
                 Mess(voluntary: false, inUnderwear: true);
-                newFullness = bowelFullness / maxBowelCapacity;
             }
             else
             {
@@ -443,19 +444,25 @@ namespace PrimevalTitmouse
 
                 StartMessing(voluntary, true); //Always in underwear in bed
                                                //Any overage in the container, add to the pants. Ignore overage over that.
+
+                Regression.monitor.Log("Mess - inUnderwear");
                 if (bowelFullness >= GetBowelAttemptThreshold())
                 {
                     _ = this.pants.AddPoop(this.underwear.AddPoop(bowelFullness));
+                    Regression.monitor.Log("Reset to 0");
                     this.bowelFullness = 0.0f;
                 }
             }
             else
             {
                 StartMessing(voluntary, false);
+                Regression.monitor.Log("Mess - not inUnderwear");
                 if (underwear.removable)
                 {
+                    Regression.monitor.Log("Removable");
                     if (bowelFullness >= GetBowelAttemptThreshold())
                     {
+                        Regression.monitor.Log("Reset to 0");
                         this.bowelFullness = 0.0f;
                     }
                 }
@@ -501,17 +508,17 @@ namespace PrimevalTitmouse
             Animations.Write(Regression.t.Poop_Overflow, this, Animations.poopAnimationTime);
             float howMessy = pants.messiness / pants.containment;
             int speedReduction = howMessy >= 0.5 ? (howMessy > 1.0 ? -3 : -2) : -1;
-            Buff buff = new Buff(0, 0, 0, 0, 0, 0, 0, 0, 0, speedReduction, 0, 0, 15, "", "")
+            Buff buff = new Buff(id: MESSY_DEBUFF, displayName: "Messy", effects: new BuffEffects() {
+                Speed = { speedReduction }
+            })
             {
                 description = string.Format("{0} {1} Speed.", Strings.RandString(Regression.t.Debuff_Messy_Pants), (object)speedReduction),
                 millisecondsDuration = 1080000,
-                glow = Color.Brown,
-                sheetIndex = -1,
-                which = MESSY_DEBUFF
+                glow = Color.Brown
             };
-            if (Game1.buffsDisplay.hasBuff(MESSY_DEBUFF))
+            if (Game1.player.hasBuff(MESSY_DEBUFF))
                 this.RemoveBuff(MESSY_DEBUFF);
-            Game1.buffsDisplay.addOtherBuff(buff);
+            Game1.player.applyBuff(buff);
         }
 
         public void StartWetting(bool voluntary = false, bool inUnderwear = true)
@@ -548,17 +555,19 @@ namespace PrimevalTitmouse
             Animations.Write(Regression.t.Pee_Overflow, this, Animations.peeAnimationTime);
 
             int defenseReduction = -Math.Max(Math.Min((int)(pants.wetness / pants.absorbency * 10.0), 10), 1);
-            Buff buff = new Buff(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, defenseReduction, 0, 15, "", "")
+
+            Buff buff = new Buff(id: WET_DEBUFF, displayName: "Wet", effects: new BuffEffects()
+            {
+                Defense = { defenseReduction }
+            })
             {
                 description = string.Format("{0} {1} Defense.", Strings.RandString(Regression.t.Debuff_Wet_Pants), defenseReduction),
-                millisecondsDuration = 1080000
+                millisecondsDuration = 1080000,
+                glow = pants.messiness != 0.0 ? Color.Brown : Color.Yellow
             };
-            buff.glow = pants.messiness != 0.0 ? Color.Brown : Color.Yellow;
-            buff.sheetIndex = -1;
-            buff.which = WET_DEBUFF;
-            if (Game1.buffsDisplay.hasBuff(WET_DEBUFF))
+            if (Game1.player.hasBuff(WET_DEBUFF))
                 this.RemoveBuff(WET_DEBUFF);
-            Game1.buffsDisplay.addOtherBuff(buff);
+            Game1.player.applyBuff(buff);
         }
 
         public void Wet(bool voluntary = false, bool inUnderwear = true)
@@ -712,18 +721,9 @@ namespace PrimevalTitmouse
             return (currentTool = Game1.player.CurrentTool as FishingRod) != null && (currentTool.isCasting || currentTool.isTimingCast || (currentTool.isNibbling || currentTool.isReeling) || currentTool.castedButBobberStillInAir || currentTool.pullingOutOfWater);
         }
 
-        public void RemoveBuff(int which)
+        public void RemoveBuff(string which)
         {
-            BuffsDisplay buffsDisplay = Game1.buffsDisplay;
-            for (int index = buffsDisplay.otherBuffs.Count - 1; index >= 0; --index)
-            {
-                if (buffsDisplay.otherBuffs[index].which == which)
-                {
-                    buffsDisplay.otherBuffs[index].removeBuff();
-                    buffsDisplay.otherBuffs.RemoveAt(index);
-                    buffsDisplay.syncIcons();
-                }
-            }
+            Game1.player.buffs.Remove(which);
         }
 
         public void Warn(float oldPercent, float newPercent, float[] thresholds, string[][] msgs, bool write = false)

--- a/Regression/PrimevalTitmouse/Container.cs
+++ b/Regression/PrimevalTitmouse/Container.cs
@@ -3,7 +3,7 @@ using StardewValley;
 
 namespace PrimevalTitmouse
 {
-
+    [Serializable]
     public class Container
     {
         public float absorbency;

--- a/Regression/PrimevalTitmouse/Container.cs
+++ b/Regression/PrimevalTitmouse/Container.cs
@@ -3,7 +3,6 @@ using StardewValley;
 
 namespace PrimevalTitmouse
 {
-    [Serializable]
     public class Container
     {
         public float absorbency;

--- a/Regression/PrimevalTitmouse/Container.cs
+++ b/Regression/PrimevalTitmouse/Container.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using StardewValley;
+using static StardewValley.Minigames.MineCart.Whale;
 
 namespace PrimevalTitmouse
 {
@@ -26,6 +28,7 @@ namespace PrimevalTitmouse
             public int season;
             public int year;
         }
+
         public Date timeWhenDoneDrying;
         private bool drying = false;
 
@@ -181,6 +184,30 @@ namespace PrimevalTitmouse
                 throw new Exception(string.Format("Invalid underwear choice: {0}", type));
 
             Initialize(c, wetness, messiness, durability);
+        }
+        public void parseDryingDate(string date)
+        {
+            if (date == "")
+            {
+                drying = false;
+                return;
+            }
+
+            string[] splitted = date.Split("-");
+            drying = true;
+
+            timeWhenDoneDrying.time = int.Parse(splitted[0]);
+            timeWhenDoneDrying.day = int.Parse(splitted[1]);
+            timeWhenDoneDrying.season = int.Parse(splitted[2]);
+            timeWhenDoneDrying.year = int.Parse(splitted[3]);
+        }
+        public string serializeDryingDate()
+        {
+            if (!drying)
+            {
+                return "";
+            }
+            return string.Format("{0}-{1}-{2}-{3}", timeWhenDoneDrying.time, timeWhenDoneDrying.day, timeWhenDoneDrying.season, timeWhenDoneDrying.year);
         }
     }
 }

--- a/Regression/PrimevalTitmouse/Mail.cs
+++ b/Regression/PrimevalTitmouse/Mail.cs
@@ -23,7 +23,7 @@ namespace PrimevalTitmouse
                 initialSupplies = new();
                 letterShown = false;
                 //Always give turnips and diapers
-                initialSupplies.Add(new StardewValley.Object(399, 20, false, -1, 0));
+                initialSupplies.Add(new StardewValley.Object("399", 20, false, -1, 0));
                 initialSupplies.Add(new Underwear("pawprint diaper", 0.0f, 0.0f, 40));
                 //If we're in Hard mode, also give pull-up.
                 if (!Regression.config.Easymode)

--- a/Regression/PrimevalTitmouse/Regression.cs
+++ b/Regression/PrimevalTitmouse/Regression.cs
@@ -123,14 +123,12 @@ namespace PrimevalTitmouse
                 int locId = 0;
                 foreach (var location in Game1.locations)
                 {
-                    int chestId = 0;
                     foreach (var obj in location.Objects.Values)
                     {
-                        var id = string.Format("{0}-{1}", locId, chestId);
+                        var id = string.Format("{0}-{1}-{2}", locId, obj.TileLocation.X, obj.TileLocation.Y);
                         if (obj is Chest chest && chestReplacement.ContainsKey(id))
                         {
                             restoreItems(chest.Items, chestReplacement[id]);
-                            chestId++;
                         }
                     }
                     locId++;
@@ -178,14 +176,12 @@ namespace PrimevalTitmouse
             int locId = 0;
             foreach (var location in Game1.locations)
             {
-                int chestId = 0;
                 foreach (var obj in location.Objects.Values)
                 {
                     if (obj is Chest chest)
                     {
-                        var id = string.Format("{0}-{1}", locId, chestId);
+                        var id = string.Format("{0}-{1}-{2}", locId, obj.TileLocation.X, obj.TileLocation.Y);
                         chestReplacements.Add(id, replaceItems(chest.Items));
-                        chestId++;
                     }
                 }
 

--- a/Regression/PrimevalTitmouse/Regression.cs
+++ b/Regression/PrimevalTitmouse/Regression.cs
@@ -37,7 +37,6 @@ namespace PrimevalTitmouse
             monitor = Monitor;
             config = Helper.ReadConfig<Config>();
             t = Helper.Data.ReadJsonFile<Data>(string.Format("{0}.json", (object)config.Lang)) ?? Helper.Data.ReadJsonFile<Data>("en.json");
-
             h.Events.GameLoop.Saving += new EventHandler<SavingEventArgs>(this.BeforeSave);
             h.Events.GameLoop.DayStarted += new EventHandler<DayStartedEventArgs>(ReceiveAfterDayStarted);
             h.Events.GameLoop.OneSecondUpdateTicking += new EventHandler<OneSecondUpdateTickingEventArgs>(ReceiveUpdateTick);
@@ -489,6 +488,11 @@ namespace PrimevalTitmouse
             //If its 6:10AM, handle delivering mail
             if (Game1.timeOfDay == 610)
                 Mail.CheckMail();
+
+            //If its earlier than 6:30, we aren't wet/messy don't notice that we're still soiled (or don't notice with ~5% chance even if soiled)
+            if (rnd.NextDouble() >= 0.0555555559694767 || body.underwear.wetness + (double)body.underwear.messiness <= 0.0 || Game1.timeOfDay < 630)
+                return;
+            Animations.AnimateStillSoiled(this.body);
         }
 
         public Regression()

--- a/Regression/PrimevalTitmouse/Regression.cs
+++ b/Regression/PrimevalTitmouse/Regression.cs
@@ -1,14 +1,16 @@
 ﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Regression;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Locations;
 using StardewValley.Menus;
+using StardewValley.Objects;
 using StardewValley.Tools;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using xTile.Dimensions;
 
 namespace PrimevalTitmouse
 {
@@ -35,6 +37,7 @@ namespace PrimevalTitmouse
             monitor = Monitor;
             config = Helper.ReadConfig<Config>();
             t = Helper.Data.ReadJsonFile<Data>(string.Format("{0}.json", (object)config.Lang)) ?? Helper.Data.ReadJsonFile<Data>("en.json");
+
             h.Events.GameLoop.Saving += new EventHandler<SavingEventArgs>(this.BeforeSave);
             h.Events.GameLoop.DayStarted += new EventHandler<DayStartedEventArgs>(ReceiveAfterDayStarted);
             h.Events.GameLoop.OneSecondUpdateTicking += new EventHandler<OneSecondUpdateTickingEventArgs>(ReceiveUpdateTick);
@@ -48,8 +51,8 @@ namespace PrimevalTitmouse
         public void DrawStatusBars()
         {
 
-            int x1 = Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea().Right - (65 + (int)((StatusBars.barWidth)));
-            int y1 = Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea().Bottom - (25 + (int)((StatusBars.barHeight)));
+            int x1 = Game1.graphics.GraphicsDevice.Viewport.TitleSafeArea.Right - (65 + (int)((StatusBars.barWidth)));
+            int y1 = Game1.graphics.GraphicsDevice.Viewport.TitleSafeArea.Bottom - (25 + (int)((StatusBars.barHeight)));
 
             if (Game1.currentLocation is MineShaft || Game1.currentLocation is Woods || Game1.currentLocation is SlimeHutch || Game1.currentLocation is VolcanoDungeon || who.health < who.maxHealth)
                 x1 -= 58;
@@ -80,7 +83,7 @@ namespace PrimevalTitmouse
             if (!config.Wetting && !config.Messing)
                 return;
             int y2 = (Game1.player.questLog).Count == 0 ? 250 : 310;
-            Animations.DrawUnderwearIcon(body.underwear, Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea().Right - 94, y2);
+            Animations.DrawUnderwearIcon(body.underwear, Game1.graphics.GraphicsDevice.Viewport.TitleSafeArea.Right - 94, y2);
         }
 
         private void GiveUnderwear()
@@ -88,9 +91,19 @@ namespace PrimevalTitmouse
             List<Item> objList = new List<Item>();
             foreach (string validUnderwearType in Strings.ValidUnderwearTypes())
                 objList.Add(new Underwear(validUnderwearType, 0.0f, 0.0f, 20));
-            objList.Add(new StardewValley.Object(399, 99, false, -1, 0));
-            objList.Add(new StardewValley.Object(348, 99, false, -1, 0));
+            objList.Add(new StardewValley.Object("399", 99, false, -1, 0));
+            objList.Add(new StardewValley.Object("348", 99, false, -1, 0));
             Game1.activeClickableMenu = new ItemGrabMenu(objList);
+        }
+
+        private static void restoreItems(StardewValley.Inventories.Inventory items, Dictionary<int, Dictionary<string, string>> invReplacement)
+        {
+            foreach (KeyValuePair<int, Dictionary<string, string>> entry in invReplacement)
+            {
+                var underwear = new Underwear();
+                underwear.rebuild(entry.Value, items[entry.Key]);
+                items[entry.Key] = underwear;
+            }
         }
 
         private void ReceiveAfterDayStarted(object sender, DayStartedEventArgs e)
@@ -98,6 +111,34 @@ namespace PrimevalTitmouse
             body = Helper.Data.ReadJsonFile<Body>(string.Format("{0}/RegressionSave.json", Constants.SaveFolderName)) ?? new Body();
             started = true;
             who = Game1.player;
+
+            var invReplacement = Helper.Data.ReadJsonFile< Dictionary<int, Dictionary<string, string>>>(string.Format("{0}/RegressionSaveInv.json", Constants.SaveFolderName));
+            if (invReplacement != null)
+            {
+                restoreItems(Game1.player.Items, invReplacement);
+            }
+
+            var chestReplacement = Helper.Data.ReadJsonFile<Dictionary<string, Dictionary<int, Dictionary<string, string>>>>(string.Format("{0}/RegressionSaveChest.json", Constants.SaveFolderName));
+            if (chestReplacement != null)
+            {
+                int locId = 0;
+                foreach (var location in Game1.locations)
+                {
+                    int chestId = 0;
+                    foreach (var obj in location.Objects.Values)
+                    {
+                        var id = string.Format("{0}-{1}", locId, chestId);
+                        if (obj is Chest chest && chestReplacement.ContainsKey(id))
+                        {
+                            restoreItems(chest.Items, chestReplacement[id]);
+                            chestId++;
+                        }
+                    }
+                    locId++;
+                }
+                restoreItems(Game1.player.Items, invReplacement);
+            }
+
             Animations.AnimateNight(body);
             HandleMorning(sender, e);
         }
@@ -105,6 +146,23 @@ namespace PrimevalTitmouse
         private void HandleMorning(object Sender, DayStartedEventArgs e)
         {
             body.HandleMorning();
+        }
+
+        private static Dictionary<int, Dictionary<string, string>> replaceItems(StardewValley.Inventories.Inventory items)
+        {
+            var replacements = new Dictionary<int, Dictionary<string, string>>();
+
+            for (int i = 0; i < items.Count; i++)
+            {
+                if (items[i] is Underwear)
+                {
+                    var underwear = (items[i] as Underwear);
+                    items[i] = underwear.getReplacement();
+                    replacements.Add(i, underwear.getAdditionalSaveData());
+                }
+            }
+
+            return replacements;
         }
 
         //Save Mod related variables in separate JSON. Also trigger night handling if not on the very first day.
@@ -116,10 +174,35 @@ namespace PrimevalTitmouse
             if (string.IsNullOrWhiteSpace(Constants.SaveFolderName))
                 return;
 
+            var chestReplacements = new Dictionary<string, Dictionary<int, Dictionary<string, string>>>();
+
+            int locId = 0;
+            foreach (var location in Game1.locations)
+            {
+                int chestId = 0;
+                foreach (var obj in location.Objects.Values)
+                {
+                    if (obj is Chest chest)
+                    {
+                        var id = string.Format("{0}-{1}", locId, chestId);
+                        chestReplacements.Add(id, replaceItems(chest.Items));
+                        chestId++;
+                    }
+                }
+
+                foreach (var furn in location.furniture.OfType<StorageFurniture>())
+                {
+                    Monitor.Log(string.Format("Found storage furniture {0}", furn.DisplayName), LogLevel.Info);
+                }
+                locId++;
+            }
+
+            var invReplacements = replaceItems(Game1.player.Items);
+
             Helper.Data.WriteJsonFile(string.Format("{0}/RegressionSave.json", Constants.SaveFolderName), body);
+            Helper.Data.WriteJsonFile(string.Format("{0}/RegressionSaveInv.json", Constants.SaveFolderName), invReplacements);
+            Helper.Data.WriteJsonFile(string.Format("{0}/RegressionSaveChest.json", Constants.SaveFolderName), chestReplacements);
         }
-
-
 
         private void ReceiveUpdateTick(object sender, OneSecondUpdateTickingEventArgs e)
         {
@@ -156,7 +239,7 @@ namespace PrimevalTitmouse
         //Determine if we need to handle time passing (not the same as Game time passing)
         private static bool ShouldTimePass()
         {
-            return ((Game1.game1.IsActive || Game1.options.pauseWhenOutOfFocus == false) && (Game1.paused == false && Game1.dialogueUp == false) && (Game1.currentMinigame == null && Game1.eventUp == false && (Game1.activeClickableMenu == null && Game1.menuUp == false)) && Game1.fadeToBlack == false);
+            return ((Game1.game1.IsActive || Game1.options.pauseWhenOutOfFocus == false) && (Game1.paused == false && Game1.dialogueUp == false) && (Game1.currentMinigame == null && Game1.eventUp == false && Game1.activeClickableMenu == null) && Game1.fadeToBlack == false);
         }
 
         //Interprete key-presses
@@ -253,8 +336,8 @@ namespace PrimevalTitmouse
                 //If enough time has passed, the bed has dried
                 if (body.bed.IsDrying())
                 {
-                    List<Response> sleepAttemptResponses = attemptToSleepMenu.responses;
-                    if (sleepAttemptResponses.Count == 2)
+                    Response[] sleepAttemptResponses = attemptToSleepMenu.responses;
+                    if (sleepAttemptResponses.Length == 2)
                     {
                         Response response = sleepAttemptResponses[1];
                         Game1.currentLocation.answerDialogue(response);
@@ -296,9 +379,8 @@ namespace PrimevalTitmouse
                     foreach(string type in availableUnderwear)
                     {
                         Underwear underwear = new Underwear(type, 0.0f, 0.0f, 1);
-                        int[] priceAndQty = new int[2] {underwear.container.price, 999};
                         currentShopMenu.forSale.Add(underwear);
-                        currentShopMenu.itemPriceAndStock.Add(underwear, priceAndQty);
+                        currentShopMenu.itemPriceAndStock.Add(underwear, new ItemStockInformation(underwear.container.price, 999));
                     }
                 }
             }
@@ -322,7 +404,7 @@ namespace PrimevalTitmouse
             int x = (int)toolLocation.X;
             int y = (int)toolLocation.Y;
             Vector2 vector2 = new Vector2((float)(x / Game1.tileSize), y / Game1.tileSize);
-            return currentLocation is BuildableGameLocation && (currentLocation as BuildableGameLocation).getBuildingAt(vector2) != null && ((currentLocation as BuildableGameLocation).getBuildingAt(vector2).buildingType.Value.Equals("Well") && (currentLocation as BuildableGameLocation).getBuildingAt(vector2).daysOfConstructionLeft.Value <= 0);
+            return currentLocation.IsBuildableLocation() && currentLocation.getBuildingAt(vector2) != null && (currentLocation.getBuildingAt(vector2).buildingType.Value.Equals("Well") && currentLocation.getBuildingAt(vector2).daysOfConstructionLeft.Value <= 0);
 
         }
 
@@ -339,7 +421,7 @@ namespace PrimevalTitmouse
             if (e.Button == SButton.MouseLeft)
             {
                 //If Left click is already being interpreted by another event (or we otherwise wouldn't process such an event. Ignore it.
-                if ((Game1.dialogueUp || Game1.currentMinigame != null || (Game1.eventUp || Game1.activeClickableMenu != null) || Game1.menuUp || Game1.fadeToBlack) || (who.isRidingHorse() || !who.canMove || (Game1.player.isEating || who.canOnlyWalk) || who.FarmerSprite.pauseForSingleAnimation))
+                if ((Game1.dialogueUp || Game1.currentMinigame != null || (Game1.eventUp || Game1.activeClickableMenu != null) || Game1.fadeToBlack) || (who.isRidingHorse() || !who.canMove || (Game1.player.isEating || who.canOnlyWalk) || who.FarmerSprite.pauseForSingleAnimation))
                     return;
 
                 ////If we're holding the watering can, attempt to drink from it.
@@ -407,11 +489,6 @@ namespace PrimevalTitmouse
             //If its 6:10AM, handle delivering mail
             if (Game1.timeOfDay == 610)
                 Mail.CheckMail();
-
-            //If its earlier than 6:30, we aren't wet/messy don't notice that we're still soiled (or don't notice with ~5% chance even if soiled)
-            if (rnd.NextDouble() >= 0.0555555559694767 || body.underwear.wetness + (double)body.underwear.messiness <= 0.0 || Game1.timeOfDay < 630)
-                return;
-            Animations.AnimateStillSoiled(this.body);
         }
 
         public Regression()

--- a/Regression/PrimevalTitmouse/Underwear.cs
+++ b/Regression/PrimevalTitmouse/Underwear.cs
@@ -5,10 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Xml.Serialization;
 
 namespace PrimevalTitmouse
 {
-    public class Underwear : StardewValley.Object, PyTK.CustomElementHandler.ISaveElement
+    public class Underwear : StardewValley.Object
     {
         public static Color color;
         public Container container;
@@ -50,7 +51,7 @@ namespace PrimevalTitmouse
         public override void drawWhenHeld(SpriteBatch spriteBatch, Vector2 objectPosition, Farmer f)
         {
             Rectangle rectangle = Animations.UnderwearRectangle(this.container, FullnessType.None, Animations.LARGE_SPRITE_DIM);
-            spriteBatch.Draw(Animations.sprites, objectPosition, new Rectangle?(rectangle), Color.White, 0.0f, Vector2.Zero, Game1.pixelZoom/(Animations.LARGE_SPRITE_DIM/Animations.SMALL_SPRITE_DIM), SpriteEffects.None, Math.Max(0.0f, (f.getStandingY() + 2) / 10000f));
+            spriteBatch.Draw(Animations.sprites, objectPosition, new Rectangle?(rectangle), Color.White, 0.0f, Vector2.Zero, Game1.pixelZoom/(Animations.LARGE_SPRITE_DIM/Animations.SMALL_SPRITE_DIM), SpriteEffects.None, Math.Max(0.0f, (f.StandingPixel.Y + 2) / 10000f));
         }
 
         public Dictionary<string, string> getAdditionalSaveData()
@@ -82,14 +83,14 @@ namespace PrimevalTitmouse
             return Game1.parseText(source.First().ToString().ToUpper() + source.Substring(1), Game1.smallFont, Game1.tileSize * 6 + Game1.tileSize / 6);
         }
 
-        public override Item getOne()
+        protected override Item GetOneNew()
         {
             return new Underwear(this.name, this.container.wetness, this.container.messiness, 1);
         }
 
-        public object getReplacement()
+        public StardewValley.Object getReplacement()
         {
-            return new StardewValley.Object(685, 1, false, -1, 0);
+            return new StardewValley.Object("685", 1, false, -1, 0);
         }
 
         public void Initialize(string type, float wetness, float messiness, int count = 1)
@@ -121,10 +122,6 @@ namespace PrimevalTitmouse
             get
             {
                 return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Status + id);
-            }
-            set
-            {
-                displayName = value;
             }
         }
 

--- a/Regression/PrimevalTitmouse/Underwear.cs
+++ b/Regression/PrimevalTitmouse/Underwear.cs
@@ -73,6 +73,10 @@ namespace PrimevalTitmouse
                 {
                   "stack",
                   string.Format("{0}",  Stack)
+                },
+                {
+                  "dryingTime",
+                  container.serializeDryingDate()
                 }
             };
         }
@@ -115,6 +119,10 @@ namespace PrimevalTitmouse
         public void rebuild(Dictionary<string, string> data, object replacement)
         {
             Initialize(data["type"], float.Parse(data["wetness"]), float.Parse(data["messiness"]), int.Parse(data["stack"]));
+            if (data.ContainsKey("dryingTime"))
+            {
+                this.container.parseDryingDate(data["dryingTime"]);
+            }
         }
 
         public override string DisplayName

--- a/Regression/Regression Dialogue/Content.json
+++ b/Regression/Regression Dialogue/Content.json
@@ -1,5 +1,5 @@
 {
-    "Format": "1.19.0",
+    "Format": "2.0.0",
     "Changes": [
 		{
             "LogName": "Sebastian",

--- a/Regression/Regression.csproj
+++ b/Regression/Regression.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 	<PropertyGroup>
@@ -10,10 +10,8 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0-beta.20210916" />
-    <PackageReference Include="Platonymous.PyTK" Version="1.12.40" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Regression/Regression/TimeMagic.cs
+++ b/Regression/Regression/TimeMagic.cs
@@ -24,17 +24,11 @@ namespace Regression
             for (int index = 0; index < 12; ++index)
             {
                 // ISSUE: method pointer
-                DelayedAction delayedAction = new DelayedAction((index + 1) * 1000 / 2)
-                {
-                    behavior = new DelayedAction.delayedBehavior(moveTimeForward)
-                };
+                DelayedAction delayedAction = new DelayedAction((index + 1) * 1000 / 2, moveTimeForward);
                 ((List<DelayedAction>)Game1.delayedActions).Add(delayedAction);
             }
             // ISSUE: method pointer
-            DelayedAction delayedAction1 = new DelayedAction(7000)
-            {
-                behavior = new DelayedAction.delayedBehavior(slowDown)
-            };
+            DelayedAction delayedAction1 = new DelayedAction(7000, slowDown);
             ((List<DelayedAction>)Game1.delayedActions).Add(delayedAction1);
         }
 

--- a/Regression/en.json
+++ b/Regression/en.json
@@ -1560,8 +1560,8 @@
 			"removable": false,
 			"durability": 0
 		},
-		"cloth diaper": {
-			"name": "cloth diaper",
+		"Cloth diaper": {
+			"name": "Cloth diaper",
 			"description": "thick and soft white cloth diaper",
 			"absorbency": 2000.0,
 			"containment": 1500.0,

--- a/Regression/manifest.json
+++ b/Regression/manifest.json
@@ -1,16 +1,11 @@
 ﻿{
   "Name": "Regression",
   "Author": "Various",
-  "Version": "1.2.9",
+  "Version": "1.3.0",
   "Description": "Diaper Wetting Mod",
   "UniqueID": "Zippity21.Regression",
   "EntryDll": "Regression.dll",
   "MinimumApiVersion": "3.13.4",
   "UpdateKeys": [ "GitHub:zippity21/Stardew_Valley_Regression_Mod" ],
-  "Dependencies": [
-    {
-      "UniqueID": "Platonymous.Toolkit",
-      "MinimumVersion": "1.22.8"
-    }
-  ]
+  "Dependencies": []
 }


### PR DESCRIPTION
Mostly by following https://stardewvalleywiki.com/Modding:Migrate_to_Stardew_Valley_1.6, but I also had a couple of extra issues I had to solve in an unconventional way (first time doing C#, really :'D)

- I had #114 happenning. Problem was that when loading the dll, it was referencing another DLL "System.Drawing.Common" that couldn't be found. I think there's a way of loading that dll in somehow, but I couldn't find it. So I removevd the part that was using System.Drawing, which was just loading the texture, to use the Mod SDK directly instead.
- The dependency on Platonymous Toolkit (PyTK) was needed to save the custom underwear data. PyTK is not yet ready for 1.6 upgrade, the only one that's ready is PyTK-lite, but that doesn't seem to work to serialize  save data. Sooo.... I had to do it manually: Every time the game is saved, I replace the items with a dummy replacement, and save the underwear state in a separate JSON file, which gets loaded at the start of day and replaces everything back.

Because of the change with save data, I don't think it will work with pre-existing saves: All the custom underwear in the player's inventory will be replaced by a random item (I think it's bait)

If you don't want to merge this and prefer to wait for PyTK's update, anyone can try this version with the following build: https://github.com/arravilo/Stardew_Valley_Regression_Mod/releases
